### PR TITLE
added documentation page with:  release name, generated date, license

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 C1541   = c1541
 AS = acme
 TAG = `git describe --tags --abbrev=0 || svnversion --no-newline`
-TAG_DEPLOY_DOT = `git describe --tags --abbrev=0`
-TAG_DEPLOY = `git describe --tags --abbrev=0 | tr . _`
+TAG_DEPLOY_DOT = `git describe --tags --abbrev=0 --dirty=-M`
+TAG_DEPLOY = `git describe --tags --abbrev=0 --dirty=_M | tr _. -_`
 
 all:	durexforth.d64
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,3 +3,4 @@
 *.out
 *.toc
 *.log
+*-g.tex

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,9 @@
 C1541 = c1541
 AS = acme
-TAG = `git describe --tags --abbrev=0 || svnversion --no-newline`
+TAG := $(shell git describe --tags --abbrev=0 || svnversion --no-newline)
+REV_TAG_P := $(shell git describe --tags --abbrev=0 --dirty=-M || svnversion --no-newline)
+REV_TAG_DOC := $(shell git describe --tags --long --dirty=_MODIFIED | sed 's/-g[0-9a-f]\+//' | tr _- -.)
+REV_DATE := $(shell git log -1 --format=%ai)
 
 # generic rules
 
@@ -15,10 +18,17 @@ durexforth.pdf:	manual.tex $(SECTIONS)
 	pdflatex -jobname=durexforth manual.tex
 
 release_license.tex: params-g.tex
+	diff -q $^ $^.tmp; if [ $$? -eq 1 ]; then touch $@; fi
+	rm $^.tmp
 
 params-g.tex:
-	echo "\\def\\releasetag{$(TAG)}" > $@
+	touch $@
+	cp $@ $@.tmp
+	echo "\\def\\revisiontagdoc{$(REV_TAG_DOC)}" > $@
+	echo "\\def\\revisiondate{$(REV_DATE)}" >> $@
 
 clean:
 	rm -f *.pdf $(GENERATED)
+
+.PHONY: $(GENERATED)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-C1541   = c1541
+C1541 = c1541
 AS = acme
 TAG = `git describe --tags --abbrev=0 || svnversion --no-newline`
 
@@ -6,8 +6,19 @@ TAG = `git describe --tags --abbrev=0 || svnversion --no-newline`
 
 all:	durexforth.pdf
 
-durexforth.pdf: anatomy.tex  editor.tex  gfx.tex    manual.tex  mml.tex asm.tex      forth.tex   intro.tex  memmap.tex  tutorial.tex sid.tex mnemonics.tex
+SECTIONS = release_license.tex \
+        intro.tex tutorial.tex editor.tex forth.tex gfx.tex sid.tex mml.tex \
+        asm.tex mnemonics.tex memmap.tex anatomy.tex
+GENERATED = params-g.tex
+
+durexforth.pdf:	manual.tex $(SECTIONS)
 	pdflatex -jobname=durexforth manual.tex
 
+release_license.tex: params-g.tex
+
+params-g.tex:
+	echo "\\def\\releasetag{$(TAG)}" > $@
+
 clean:
-	rm -f *.pdf
+	rm -f *.pdf $(GENERATED)
+

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -7,11 +7,11 @@
 \usepackage{multicol}
 \usepackage{alltt}
 
+\hypersetup{pdfauthor="Ravelli/Durex", pdftitle="durexForth: Operators Manual", colorlinks=true}
+\begin{document}
 \author{Ravelli/Durex}
 \title{durexForth: Operators Manual}
 
-\hypersetup{pdfauthor="Ravelli/Durex", pdftitle="durexForth: Operators Manual", colorlinks=true}
-\begin{document}
 \pagestyle{empty} % No page number on first page!
 \AddToShipoutPicture*{
 	\includegraphics[width=21cm]{cover/durexForth-Vintage1.jpg}
@@ -19,6 +19,9 @@
 \phantom{Invisible, but important}
 \newpage 
 \pagestyle{plain}
+
+\input{release_license.tex}
+
 \tableofcontents
 
 \input{intro.tex}

--- a/docs/release_license.tex
+++ b/docs/release_license.tex
@@ -2,7 +2,7 @@
 
 \setlength{\parindent}{0pt}
 
-Release \texttt{\releasetag}\space (\today)\\[18pt]
+Release \texttt{\revisiontagdoc}, \space \revisiondate\\[18pt]
 
 The MIT License\\
 
@@ -10,7 +10,7 @@ Copyright (c) 2008-\the\year \space Johan Kotlinski, Mats Andren
 
 \begin{flushleft}
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
+of this software and associated documentation files (the ``Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
@@ -23,7 +23,7 @@ all copies or substantial portions of the Software.
 \end{flushleft}
 
 \begin{flushleft}
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED ``AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER

--- a/docs/release_license.tex
+++ b/docs/release_license.tex
@@ -1,0 +1,34 @@
+\input{params-g.tex}
+
+\setlength{\parindent}{0pt}
+
+Release \texttt{\releasetag}\space (\today)\\[18pt]
+
+The MIT License\\
+
+Copyright (c) 2008-\the\year \space Johan Kotlinski, Mats Andren
+
+\begin{flushleft}
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+\end{flushleft}
+
+\begin{flushleft}
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+\end{flushleft}
+
+\begin{flushleft}
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+\end{flushleft}
+

--- a/ext/.gitignore
+++ b/ext/.gitignore
@@ -1,1 +1,2 @@
 petcom.exe
+petcom


### PR DESCRIPTION
I wanted to know what version of the document I'm reading when I've printed out the document. So, in the PDF, I added a simple page before table of contents that contains:

- release version (uses TAG from Makefile)
- document generation date (uses default formatting)
- MIT license text (from durexforth.asm) with generated end date

(all the LaTeX commands used are from what I learned today, so please let me know if I used poor form)