### PR TITLE
[FR] Show 'position/size' in the editor statusbar

### DIFF
--- a/forth_src/v.fs
+++ b/forth_src/v.fs
@@ -468,6 +468,14 @@ linelen dup if 1- then min
 curx c! then cursor-scr-pos
 dup @ $80 or swap c!
 
+\ show position
+$7e8 >r
+eof @ bufstart - 1- 0 <# #s #>
+r> over - dup >r swap move
+r> 1- '/' over c! >r
+editpos bufstart - 0 <# #s #>
+r> over - swap move
+
 key
 
 \ hide cursor
@@ -479,7 +487,8 @@ dup $88 = if 2drop cleanup rom-kernal
 bufstart eof @ bufstart - 1-
 evaluate quit then
 
-insert if do-insert else do-main if
+insert if do-insert else
+$7dd 11 bl fill do-main if
 drop rom-kernal cleanup exit then then
 
 need-refresh if show-page else


### PR DESCRIPTION
Submitted for your consideration, 126 additional bytes in the dictionary adding a display bottom right in the editor, showing the current cursor position and the total length of the file (minus the prg header, I guess).

Alternatives:
- `x/100% (size)`
- `line, column` (not that useful without the size)
- `line/lines, column
- also display the number of blocks it takes on disk
- the best of all of the above
- not including it at all

All these will cost more bytes, of course. I measured the size by comparing `here` with and without the addition. How can I tell how many bytes are left free, other than watching the cart build fail? xD
