### PR TITLE
ls update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - LS now accepts wildcards, drive #'s or not.
+### Added
+ - RDIR will display directory formatted data anywhere in memory.
+
+## [2.0.0] - 2020-04-26
+
+## [Unreleased]
+
 ###Fixed
  - v did not compile in DECIMAL mode.
 
@@ -219,7 +228,7 @@ Thanks to Christian Johansson and polluks for bug reports!
 
 ## [1.4.2] - 2015-10-30
 
- - renamed EOL comment # to \ (PC) or £ (C64)
+ - renamed EOL comment # to \ (PC) or Â£ (C64)
  - renamed :asm => code
  - renamed ;asm => ;code
  - renamed tell => type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - LS now accepts wildcards, drive #'s or not.
- - Made MORE optional via variable MORE?
+ - Made MORE optional via value MORE?
 ### Added
  - RDIR will display directory formatted data anywhere in memory.
- - variable  MORE?  default value TRUE
  - constants TRUE and FALSE
+ - value MORE?  default value TRUE
  
 ## [2.0.0] - 2020-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - LS now accepts wildcards, drive #'s or not.
+ - Made MORE optional via variable MORE?
 ### Added
  - RDIR will display directory formatted data anywhere in memory.
-
+ - variable  MORE?  default value TRUE
+ - constants TRUE and FALSE
+ 
 ## [2.0.0] - 2020-04-26
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Made MORE optional via value MORE?
 ### Added
  - RDIR will display directory formatted data anywhere in memory.
- - constants TRUE and FALSE
- - value MORE?  default value TRUE
- 
-## [2.0.0] - 2020-04-26
-
-## [Unreleased]
-
-###Fixed
+### Fixed
  - v did not compile in DECIMAL mode.
 
 ## [2.0.0] - 2020-03-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - LS now accepts wildcards, drive #'s or not.
- - Made MORE optional via value MORE?
-### Added
+ ### Added
  - RDIR will display directory formatted data anywhere in memory.
 ### Fixed
  - v did not compile in DECIMAL mode.

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -380,7 +380,7 @@ forget
 \item[saveb ( start end filenameptr filenamelength -- )] Save binary block.
 \item[device ( device\# -- )] Switches the active device. 8 to 11 are valid device \#'s.
 \item[save-forth filename ( -- )] Saves the forth to the given filename.
-\item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards. Example: \texttt{ ls $1:*=p } Load directory, drive 1 only .prg files.
+\item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards. Example: \texttt{ ls \$1:*=p } Load directory, drive 1 only .prg files.
 \item[rdir ( addr -- )] Display disk directory previously loaded to addr.
 \end{description}
 

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -380,8 +380,7 @@ forget
 \item[saveb ( start end filenameptr filenamelength -- )] Save binary block.
 \item[device ( device\# -- )] Switches the active device. 8 to 11 are valid device \#'s.
 \item[save-forth filename ( -- )] Saves the forth to the given filename.
-\item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards.
-Example: \texttt{ ls $1:*=p } Load directory, drive 1 only .prg files.
+\item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards. Example: \texttt{ ls $1:*=p } Load directory, drive 1 only .prg files.
 \item[rdir ( addr -- )] Display disk directory previously loaded to addr.
 \end{description}
 

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -378,7 +378,7 @@ forget
 \item[required ( filenameptr filenamelength -- )] Like included, except that load is skipped if the file is already loaded.
 \item[loadb ( filenameptr filenamelength dst -- endaddr )] Load binary block to dst. Returns 0 on failure, otherwise address after last written byte.
 \item[saveb ( start end filenameptr filenamelength -- )] Save binary block.
-\item[device ( device\# -- )] Switches the active device. 8 to 11 are valid device \#'s.
+\item[device ( device\# -- )] Switches the active device.
 \item[save-forth filename ( -- )] Saves the forth to the given filename.
 \item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards. Example: \texttt{ls \$1:*=p} Load directory, drive 1 only prg files.
 \item[rdir ( addr -- )] Display disk directory previously loaded to addr.

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -380,7 +380,7 @@ forget
 \item[saveb ( start end filenameptr filenamelength -- )] Save binary block.
 \item[device ( device\# -- )] Switches the active device. 8 to 11 are valid device \#'s.
 \item[save-forth filename ( -- )] Saves the forth to the given filename.
-\item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards. Example: \texttt{ ls \$1:*=p } Load directory, drive 1 only .prg files.
+\item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards. Example: \texttt{ls \$1:*=p} Load directory, drive 1 only prg files.
 \item[rdir ( addr -- )] Display disk directory previously loaded to addr.
 \end{description}
 

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -378,8 +378,11 @@ forget
 \item[required ( filenameptr filenamelength -- )] Like included, except that load is skipped if the file is already loaded.
 \item[loadb ( filenameptr filenamelength dst -- endaddr )] Load binary block to dst. Returns 0 on failure, otherwise address after last written byte.
 \item[saveb ( start end filenameptr filenamelength -- )] Save binary block.
-\item[device ( device\# -- )] Switches the active device. 8 to 11 are valid device\#'s.
+\item[device ( device\# -- )] Switches the active device. 8 to 11 are valid device \#'s.
 \item[save-forth filename ( -- )] Saves the forth to the given filename.
+\item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards.
+Example: \texttt{ ls $1:*=p } Load directory, drive 1 only .prg files.
+\item[rdir ( addr -- )] Display disk directory previously loaded to addr.
 \end{description}
 
 \section{Compatibility}

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -85,8 +85,6 @@ msb lda,x lsb sta,x
 dup code lda,# 100/ ldy,#
 ['] pushya jmp, ;
 : constant value ;
--1 constant true
-0 constant false
 
 : space bl emit ;
 : spaces ( n -- )

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -85,6 +85,8 @@ msb lda,x lsb sta,x
 dup code lda,# 100/ ldy,#
 ['] pushya jmp, ;
 : constant value ;
+-1 constant true
+0 constant false
 
 : space bl emit ;
 : spaces ( n -- )

--- a/forth_src/debug.fs
+++ b/forth_src/debug.fs
@@ -84,10 +84,9 @@ emit 1+ loop cr loop
 last-dump ! base ! ;
 : n last-dump @ dump ;
 
--1 constant true
-0 constant false
 variable more?
 true more? !
+
 : more more? if  
 $d6 c@ $18 = if $12 emit
 ." more" $92 emit key drop page then then ;

--- a/forth_src/debug.fs
+++ b/forth_src/debug.fs
@@ -82,11 +82,16 @@ space 1+ loop drop
 dup $7f and $20 < if drop '.' then
 emit 1+ loop cr loop
 last-dump ! base ! ;
-
 : n last-dump @ dump ;
 
-: more $d6 c@ $18 = if $12 emit
-." more" $92 emit key drop page then ;
+-1 constant true
+0 constant false
+variable more?
+true more? !
+: more more? if  
+$d6 c@ $18 = if $12 emit
+." more" $92 emit key drop page then then ;
+
 : words
 page latest @ begin ?dup while
 more dup name>string type space @ repeat cr ;

--- a/forth_src/debug.fs
+++ b/forth_src/debug.fs
@@ -84,10 +84,9 @@ emit 1+ loop cr loop
 last-dump ! base ! ;
 : n last-dump @ dump ;
 
-variable more?
-true more? !
+true value more?
 
-: more more? @ if  
+: more more? if  
 $d6 c@ $18 = if $12 emit
 ." more" $92 emit key drop page then then ;
 

--- a/forth_src/debug.fs
+++ b/forth_src/debug.fs
@@ -87,7 +87,7 @@ last-dump ! base ! ;
 variable more?
 true more? !
 
-: more more? if  
+: more more? @ if  
 $d6 c@ $18 = if $12 emit
 ." more" $92 emit key drop page then then ;
 

--- a/forth_src/debug.fs
+++ b/forth_src/debug.fs
@@ -84,11 +84,9 @@ emit 1+ loop cr loop
 last-dump ! base ! ;
 : n last-dump @ dump ;
 
-true value more?
-
-: more more? if  
+: more 
 $d6 c@ $18 = if $12 emit
-." more" $92 emit key drop page then then ;
+." more" $92 emit key drop page then ;
 
 : words
 page latest @ begin ?dup while

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -1,11 +1,12 @@
 \ submitted by kevin reno
 
-: ls begin ?dup while
-2+ dup @ . 2+
-begin dup c@ ?dup while
-emit 1+ repeat 1+ cr
-dup c@ 0= if c@ then
-repeat ;
+: ls ( addr -- )
+begin ?dup while        / abort if addr = 0
+2+ dup @ . 2+           / skip line link, print blocks
+begin dup c@ ?dup while / eol?
+emit 1+ repeat 1+ cr    / print line, eol
+dup c@ 0= if c@ then    / if eof then addr = 0
+repeat ;                
 
 \ sample code
 \ $c000 try $0:*=s

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -1,7 +1,26 @@
 \ submitted by kevin reno
 
-: ls s" $" here loadb 2 - here
+: ls
+$f word count dup 0<> if
+tuck here 3 + swap move
+3 + here
+'$' over c!
+'0' over 1+ c!
+':' over 2+ c!
+tuck
+else 2drop s" $" here then
+loadb 2 - here
 begin 2dup <> while
 2+ dup @ . space 2+
 begin dup c@ ?dup while
-emit 1+ repeat 1+ cr repeat 2drop ;
+emit 1+ repeat 1+ cr
+more repeat 2drop ;
+
+
+
+
+
+
+
+
+

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -1,6 +1,6 @@
 \ submitted by kevin reno
 
-: ls ( addr -- )
+: rdir ( addr -- )
 begin ?dup while        \ abort if addr = 0
 2+ dup @ . 2+           \ skip line link, print blocks
 begin dup c@ ?dup while \ eol?
@@ -8,10 +8,11 @@ emit 1+ repeat 1+ cr    \ print line, eol
 dup c@ 0= if c@ then    \ if eof then addr = 0
 repeat ;                
 
-\ sample code
-\ $c000 try $0:*=s
-\ : try ( addr -- ) 
-\ dup parse-name rot loadb drop ls ;
+: ls parse-name ?dup if  \ accepts wildcards or not 
+else drop s" $"  
+then here loadb drop here rdir ;
+
+: bs here rdir ;  \ careful, if pad has changed
 
 
 

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -1,20 +1,31 @@
 \ submitted by kevin reno
 
-: ls
-$f word count dup 0<> if
-tuck here 3 + swap move
-3 + here
-'$' over c!
-'0' over 1+ c!
-':' over 2+ c!
-tuck
-else 2drop s" $" here then
-loadb 2 - here
-begin 2dup <> while
-2+ dup @ . space 2+
+: ls ( addr -- )
+begin ?dup while
+2+ dup @ . 2+
 begin dup c@ ?dup while
 emit 1+ repeat 1+ cr
-more repeat 2drop ;
+dup c@ 0= if drop 0 then
+more repeat ;
+
+\ sample code
+\ $c000 try $0:*=s
+\ : try ( addr -- ) 
+\ dup parse-name rot loadb drop ls ;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -2,7 +2,7 @@
 
 : rdir ( addr -- )
 begin ?dup while        \ abort if addr = 0
-2+ dup @ . 2+           \ skip line link, print blocks
+more 2+ dup @ . 2+      \ skip line link, print blocks
 begin dup c@ ?dup while \ eol?
 emit 1+ repeat 1+ cr    \ print line, eol
 dup c@ 0= if c@ then    \ if eof then addr = 0

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -1,12 +1,11 @@
 \ submitted by kevin reno
 
-: ls ( addr -- )
-begin ?dup while
+: ls begin ?dup while
 2+ dup @ . 2+
 begin dup c@ ?dup while
 emit 1+ repeat 1+ cr
-dup c@ 0= if drop 0 then
-more repeat ;
+dup c@ 0= if c@ then
+repeat ;
 
 \ sample code
 \ $c000 try $0:*=s

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -12,7 +12,6 @@ repeat ;
 else drop s" $"  
 then here loadb drop here rdir ;
 
-: bs here rdir ;  \ careful, if pad has changed
 
 
 

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -11,27 +11,3 @@ repeat ;
 : ls parse-name ?dup if  \ accepts wildcards or not 
 else drop s" $"  
 then here loadb drop here rdir ;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/forth_src/ls.fs
+++ b/forth_src/ls.fs
@@ -1,11 +1,11 @@
 \ submitted by kevin reno
 
 : ls ( addr -- )
-begin ?dup while        / abort if addr = 0
-2+ dup @ . 2+           / skip line link, print blocks
-begin dup c@ ?dup while / eol?
-emit 1+ repeat 1+ cr    / print line, eol
-dup c@ 0= if c@ then    / if eof then addr = 0
+begin ?dup while        \ abort if addr = 0
+2+ dup @ . 2+           \ skip line link, print blocks
+begin dup c@ ?dup while \ eol?
+emit 1+ repeat 1+ cr    \ print line, eol
+dup c@ 0= if c@ then    \ if eof then addr = 0
 repeat ;                
 
 \ sample code


### PR DESCRIPTION
 ls will accept drive#, wildcards or not.

 Spun off rdir will read directory loaded to arbitrary address.

bs added to display directory without reloading.

 Should more be added to ls?
If so, should it be a variable that you can set if you want it or not?
Would that be overkill?

