### PR TITLE
Mostly implemented SEARCH-ORDER

### DIFF
--- a/compiler.asm
+++ b/compiler.asm
@@ -121,9 +121,12 @@ SEMICOLON
     +BACKLINK
     !byte	9
     !text	"immediate"
-    lda	_LATEST
+    lda CURRENT
+    asl
+    tay
+    lda	WIDS,y
     sta	W
-    lda	_LATEST + 1
+    lda	WIDS+1,y
     sta	W + 1
     ldy	#2
     lda	(W), y
@@ -147,10 +150,13 @@ COLON
 
     ; Hides the word.
     dex
-    lda	_LATEST
+    lda CURRENT
+    asl
+    tay
+    lda WIDS,y	
     sta	W
     sta LSB, x
-    lda	_LATEST + 1
+    lda	WIDS+1,y
     sta W + 1
     sta MSB, x
 
@@ -296,7 +302,7 @@ LITERAL
 HERE
 HERE_LSB = * + 1
 HERE_MSB = * + 3
-    +VALUE	_LATEST + 2
+    +VALUE	BASE_HERE
 
     !word	LINK
     !set	LINK = * - 2

--- a/durexforth.asm
+++ b/durexforth.asm
@@ -156,6 +156,7 @@ ONE
 !src "core.asm"
 !src "math.asm"
 !src "move.asm"
+!src "searchorder.asm"
 !src "interpreter.asm"
 !src "compiler.asm"
 !src "control.asm"
@@ -175,6 +176,10 @@ _LATEST
 ; ALL CONTENTS BELOW LATEST WILL BE OVERWRITTEN!!!
 
 load_base
+    lda _LATEST
+    sta WIDS
+    lda _LATEST+1
+    sta WIDS+1
     lda #<QUIT
     sta _START
     lda #>QUIT

--- a/durexforth.asm
+++ b/durexforth.asm
@@ -169,16 +169,25 @@ ONE
     !byte 6
     !text	"latest"
 LATEST
-    +VALUE	_LATEST
-_LATEST
-    !word	LINK
+    dex
+    lda CURRENT
+    asl ; 0 certain to carry
+    ; clc
+    adc #<WIDS
+    sta LSB,x
+    lda #>WIDS
+    adc #0
+    sta MSB,x
+    rts
 
-; ALL CONTENTS BELOW LATEST WILL BE OVERWRITTEN!!!
+BASE_HERE
+
+; ALL CONTENTS BELOW BASE_HERE WILL BE OVERWRITTEN!!!
 
 load_base
-    lda _LATEST
+    lda #<LINK
     sta WIDS
-    lda _LATEST+1
+    lda #>LINK
     sta WIDS+1
     lda #<QUIT
     sta _START

--- a/forth_src/searchorder.fs
+++ b/forth_src/searchorder.fs
@@ -1,0 +1,9 @@
+: only -1 set-order ;
+: also get-order over swap 1+ set-order ;
+: (wordlist)
+create , does> 
+@ >r get-order nip r> swap set-order ;
+forth-wordlist (wordlist) forth
+: order \ TODO
+;
+: previous get-order nip 1- set-order ;

--- a/forth_src/searchorder.fs
+++ b/forth_src/searchorder.fs
@@ -1,9 +1,15 @@
+
+\ core words, unimplimented by default
+: definitions get-order 1- swap set-current
+0 do nip loop ;
+1 value forth-wordlist
+\ extension words
 : only -1 set-order ;
 : also get-order over swap 1+ set-order ;
 : (wordlist)
 create , does> 
 @ >r get-order nip r> swap set-order ;
 forth-wordlist (wordlist) forth
-: order \ TODO
-;
+: order ." Order: " get-order 0 do . loop
+." Current: " get-current . cr;
 : previous get-order nip 1- set-order ;

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -251,16 +251,6 @@ FIND_NAME ; ( caddr u -- caddr u 0 | xt 1 | xt -1 )
     txa
     pha
 
-    lda CURRENT
-    sec
-    sbc #1
-    asl
-    tay
-    lda _LATEST
-    sta WIDS,y
-    lda _LATEST+1
-    sta WIDS+1,y
-
     lda LSB,x
     beq .find_failed
     sta	.findlen + 1
@@ -280,17 +270,14 @@ FIND_NAME ; ( caddr u -- caddr u 0 | xt 1 | xt -1 )
     dec W2+1
 +   dec W2
 
-    lda #$0
+    lda #0
     cmp _ORDER
     beq .find_failed
     sta W3
 .next_wid
     ldy W3
     lda CONTEXT,y
-    beq .find_failed
     inc W3
-    sec
-    sbc #1
     asl
     tay
     ldx	WIDS,y

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -251,6 +251,16 @@ FIND_NAME ; ( caddr u -- caddr u 0 | xt 1 | xt -1 )
     txa
     pha
 
+    lda CURRENT
+    sec
+    sbc #1
+    asl
+    tay
+    lda _LATEST
+    sta WIDS,y
+    lda _LATEST+1
+    sta WIDS+1,y
+
     lda LSB,x
     beq .find_failed
     sta	.findlen + 1
@@ -270,8 +280,21 @@ FIND_NAME ; ( caddr u -- caddr u 0 | xt 1 | xt -1 )
     dec W2+1
 +   dec W2
 
-    ldx	_LATEST
-    lda	_LATEST + 1
+    lda #$0
+    cmp _ORDER
+    beq .find_failed
+    sta W3
+.next_wid
+    ldy W3
+    lda CONTEXT,y
+    beq .find_failed
+    inc W3
+    sec
+    sbc #1
+    asl
+    tay
+    ldx	WIDS,y
+    lda	WIDS+1,y
 .examine_word
     sta	W + 1
     stx	W
@@ -292,7 +315,9 @@ FIND_NAME ; ( caddr u -- caddr u 0 | xt 1 | xt -1 )
     lda	(W), y
     ; Is word null? If not, examine it.
     bne .examine_word
-
+    lda W3
+    cmp _ORDER
+    bne .next_wid
     ; It is null - give up.
 .find_failed
     pla

--- a/searchorder.asm
+++ b/searchorder.asm
@@ -1,0 +1,169 @@
+;{{{ The MIT License
+;
+;Copyright (c) 2020 Poindexter Frink
+;
+;Permission is hereby granted, free of charge, to any person obtaining a copy
+;of this software and associated documentation files (the "Software"), to deal
+;in the Software without restriction, including without limitation the rights
+;to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;copies of the Software, and to permit persons to whom the Software is
+;furnished to do so, subject to the following conditions:
+;
+;The above copyright notice and this permission notice shall be included in
+;all copies or substantial portions of the Software.
+;
+;THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+;THE SOFTWARE. }}}
+
+; DEFINITIONS FORTH-WORDLIST GET-CURRENT GET-ORDER SET-CURRENT SET-ORDER
+; WORDLIST
+
+WIDS
+    !fill 16, 0
+_ORDER
+    !byte 1
+
+CONTEXT
+    !byte 1
+    !fill 7, 0
+
+    +BACKLINK
+    !byte	14
+    !text	"forth-wordlist"
+    +VALUE 1
+
+    +BACKLINK
+    !byte   9
+    !text   "get-order"
+    lda #0
+    sta W
+    ldy _ORDER
+    beq .gdone_count
+.gpush_wid
+    dey
+    dex
+    lda CONTEXT,y
+    sta LSB,x
+    lda #0 
+    sta MSB,x
+    inc W
+    cpy #0
+    bne .gpush_wid
+.gdone_count
+    dex
+    sta MSB,x
+    ldy W
+    sty LSB,x
+    rts
+
+    +BACKLINK
+    !byte	9
+    !text	"set-order"
+
+    lda LSB,x
+    cmp #$ff
+    bne .set_not_negative
+    lda MSB,x
+    cmp #$ff
+    bne .set_not_negative
+    
+    lda #1 
+    sta CONTEXT
+    lda #1
+    sta _ORDER
+    inx
+    rts
+.set_not_negative
+    jsr DUP
+    jsr ZEQU
+    lda LSB,x
+    beq .set_not_zero
+    lda #0
+    sta _ORDER
+    inx
+    inx
+    rts
+.set_not_zero
+    inx
+    lda LSB,x
+    sta _ORDER
+    inx
+    ldy #0
+.set_pull_wid
+    lda LSB,x
+    sta CONTEXT,y
+    inx
+    iny
+    cpy _ORDER
+    bne .set_pull_wid
+    rts
+
+    +BACKLINK
+    !byte   11
+    !text   "set-current"
+SET_CURRENT
+    ; save the current latest pointer
+    lda CURRENT
+    sec
+    sbc #1
+    asl
+    tay
+    lda _LATEST
+    sta WIDS,y
+    lda _LATEST+1
+    sta WIDS+1,y
+    ; update current
+    lda LSB,x
+    sta CURRENT
+    ; update the latest pointer
+    sec
+    sbc #1
+    asl
+    tay
+    lda WIDS,y
+    sta _LATEST
+    lda WIDS+1,y
+    sta _LATEST+1
+    inx
+    rts
+
+    +BACKLINK
+    !byte   11
+    !text   "get-current"
+    dex
+    lda CURRENT
+    sta LSB,x
+    lda #0
+    sta MSB,x
+    rts
+CURRENT
+    !byte 1
+NEXT_WID
+    !byte 2
+    
+    +BACKLINK
+    !byte 8
+    !text "wordlist"
+    dex
+    lda NEXT_WID
+    inc NEXT_WID
+    sta LSB,x
+    lda #0
+    sta MSB,x
+    rts
+    
+    +BACKLINK
+    !byte 11
+    !text "definitions"
+    dex
+    lda CONTEXT
+    sta LSB,x
+    lda #0
+    sta MSB,x
+    jmp SET_CURRENT
+

--- a/searchorder.asm
+++ b/searchorder.asm
@@ -23,24 +23,16 @@
 ; DEFINITIONS FORTH-WORDLIST GET-CURRENT GET-ORDER SET-CURRENT SET-ORDER
 ; WORDLIST
 
-WIDS
+WIDS ; lastest for each wordlist
     !fill 16, 0
 _ORDER
     !byte 1
-
 CONTEXT
     !fill 8, 0
 
     +BACKLINK
-    !byte	14
-    !text	"forth-wordlist"
-    +VALUE 1
-
-    +BACKLINK
     !byte   9
     !text   "get-order"
-    lda #0
-    sta W
     ldy _ORDER
     beq .gdone_count
 .gpush_wid
@@ -52,15 +44,11 @@ CONTEXT
     sta LSB,x
     lda #0 
     sta MSB,x
-    inc W
     cpy #0
     bne .gpush_wid
 .gdone_count
-    dex
-    sta MSB,x
-    ldy W
-    sty LSB,x
-    rts
+    lda _ORDER
+    jmp pushya 
 
     +BACKLINK
     !byte	9
@@ -90,7 +78,7 @@ CONTEXT
     inx
     rts
 .set_not_zero
-    inx
+    inx 
     lda LSB,x
     sta _ORDER
     inx
@@ -128,28 +116,34 @@ SET_CURRENT
     rts
 CURRENT
     !byte 0
-NEXT_WID
-    !byte 1
     
     +BACKLINK
     !byte 8
     !text "wordlist"
     dex
-    inc NEXT_WID
-    lda NEXT_WID
+NEXT_WID
+    lda #2 
     sta LSB,x
     lda #0
     sta MSB,x
+    inc NEXT_WID+1
     rts
-    
-    +BACKLINK
-    !byte 11
-    !text "definitions"
-    dex
-    ldy CONTEXT
-    iny
-    sta LSB,x
-    lda #0
-    sta MSB,x
-    jmp SET_CURRENT
+
+; redundant to: get-order 1- 0 do nip loop    
+;    +BACKLINK
+;    !byte 11
+;    !text "definitions"
+;    dex
+;    ldy CONTEXT
+;    iny
+;    sta LSB,x
+;    lda #0
+;    sta MSB,x
+;    jmp SET_CURRENT
+;
+; constant value can be documented, inferred from -1 set-order
+;    +BACKLINK
+;    !byte	14
+;    !text	"forth-wordlist"
+;    +VALUE 1
 

--- a/searchorder.asm
+++ b/searchorder.asm
@@ -29,8 +29,7 @@ _ORDER
     !byte 1
 
 CONTEXT
-    !byte 1
-    !fill 7, 0
+    !fill 8, 0
 
     +BACKLINK
     !byte	14
@@ -48,6 +47,8 @@ CONTEXT
     dey
     dex
     lda CONTEXT,y
+    clc
+    adc #1
     sta LSB,x
     lda #0 
     sta MSB,x
@@ -72,7 +73,7 @@ CONTEXT
     cmp #$ff
     bne .set_not_negative
     
-    lda #1 
+    lda #0 
     sta CONTEXT
     lda #1
     sta _ORDER
@@ -96,6 +97,8 @@ CONTEXT
     ldy #0
 .set_pull_wid
     lda LSB,x
+    sec
+    sbc #1
     sta CONTEXT,y
     inx
     iny
@@ -107,28 +110,9 @@ CONTEXT
     !byte   11
     !text   "set-current"
 SET_CURRENT
-    ; save the current latest pointer
-    lda CURRENT
-    sec
-    sbc #1
-    asl
-    tay
-    lda _LATEST
-    sta WIDS,y
-    lda _LATEST+1
-    sta WIDS+1,y
-    ; update current
-    lda LSB,x
-    sta CURRENT
-    ; update the latest pointer
-    sec
-    sbc #1
-    asl
-    tay
-    lda WIDS,y
-    sta _LATEST
-    lda WIDS+1,y
-    sta _LATEST+1
+    ldy LSB,x
+    dey
+    sty CURRENT
     inx
     rts
 
@@ -136,22 +120,23 @@ SET_CURRENT
     !byte   11
     !text   "get-current"
     dex
-    lda CURRENT
-    sta LSB,x
+    ldy CURRENT
+    iny
+    sty LSB,x
     lda #0
     sta MSB,x
     rts
 CURRENT
-    !byte 1
+    !byte 0
 NEXT_WID
-    !byte 2
+    !byte 1
     
     +BACKLINK
     !byte 8
     !text "wordlist"
     dex
-    lda NEXT_WID
     inc NEXT_WID
+    lda NEXT_WID
     sta LSB,x
     lda #0
     sta MSB,x
@@ -161,7 +146,8 @@ NEXT_WID
     !byte 11
     !text "definitions"
     dex
-    lda CONTEXT
+    ldy CONTEXT
+    iny
     sta LSB,x
     lda #0
     sta MSB,x


### PR DESCRIPTION
Here is a simple implementation of the SEARCH-ORDER wordset (except for SEARCH-WORDLIST).

As it is an increase in size, the cartridge will not build. (edit: it's only a few bytes off, which can be trimmed by reducing a few internal words to NONAMEs with helper functions in a different wordlist)

I don't expect this to be merged any time soon, if at all.  I just put it out here as an idea, given the discussion about changes to the dictionary.

Enjoy!

edit: WORDS will need SEARCH-WORDLIST to comply with the standard:
"List the definition names in the first word list of the search order."
Currently, it shows the CURRENT wordlist, not the first in the search order.

MARKER will also need an update to backup and restore WIDS, _ORDER, and CONTEXT