### PR TITLE
Minimal Split Dictionary, redux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - LS now accepts wildcards, drive #'s or not.
  - Dictionary restructured, now header and code data are split.
- - Header data is not a linked list, and grows downward from a default TOP of $6fff. Record structure: `len_flags | str | xt`
+ - Header data is not a linked list, and grows downward from $9fff. Record structure: `len_flags | str | xt`
  - Prompt displays `ful` when there is less than 256 bytes of dictionary space left.
 ### Added
  - RDIR will display directory formatted data anywhere in memory.
  - PAD Scratch pad memory set to cassette buffer. Untouched by DurexForth
+ - DOWORDS, which allows executing an xt for every word in the wordlist 
+ - Turn-key operation utilities in TURNKEY:
  - SAVE-PACK packs the dictionary together before saving, which unpacks at runtime.
  - SAVE-PRG removes the dictionary and saves the program
  - TOP returns the address of the last byte of the header structure. The value at this address will always be 0.
  - TOP! can be used to specify the position of header data.
- - DOWORDS can be used to scan the header records.
 ### Fixed
  - V did not compile in DECIMAL mode.
  - V long line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - LS now accepts wildcards, drive #'s or not.
+ - Dictionary restructured, now header and code data are split.
+ - Header data is not a linked list, and grows downward from a default TOP of $6fff. Record structure: `len_flags | str | xt`
+ - Prompt displays `ful` when there is less than 256 bytes of dictionary space left.
 ### Added
  - RDIR will display directory formatted data anywhere in memory.
  - PAD Scratch pad memory set to cassette buffer. Untouched by DurexForth
+ - SAVE-PACK packs the dictionary together before saving, which unpacks at runtime.
+ - SAVE-PRG removes the dictionary and saves the program
+ - TOP returns the address of the last byte of the header structure. The value at this address will always be 0.
+ - TOP! can be used to specify the position of header data.
+ - DOWORDS can be used to scan the header records.
 ### Fixed
  - V did not compile in DECIMAL mode.
  - V long line

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TAG_DEPLOY = `git describe --tags --abbrev=0 --dirty=_M | tr _. -_`
 SRC_DIR = forth_src
 SRC_NAMES = base debug v asm gfx gfxdemo rnd sin ls turtle fractals \
     sprite doloop sys labels mml mmldemo sid spritedemo test testcore \
-    testcoreplus tester format require compat timer float viceutil
+    testcoreplus tester format require compat timer float viceutil turnkey
 SRCS = $(addprefix $(SRC_DIR)/,$(addsuffix .fs,$(SRC_NAMES)))
 
 EMPTY_FILE = _empty.txt

--- a/control.asm
+++ b/control.asm
@@ -22,9 +22,7 @@
 
 ; IF THEN BEGIN WHILE REPEAT BRANCH 0BRANCH UNLOOP EXIT
 
-    +BACKLINK
-    !byte 2 | F_IMMEDIATE
-    !text	"if"
+    +BACKLINK "if", 2 | F_IMMEDIATE
     jsr LIT
     !word ZBRANCH
     jsr COMPILE_COMMA
@@ -32,21 +30,15 @@
     jsr ZERO
     jmp COMMA
 
-    +BACKLINK
-    !byte 4 | F_IMMEDIATE
-    !text	"then"
+    +BACKLINK "then", 4 | F_IMMEDIATE
     jsr HERE
     jsr SWAP
     jmp STORE
 
-    +BACKLINK
-    !byte 5 | F_IMMEDIATE
-    !text	"begin"
+    +BACKLINK "begin", 5 | F_IMMEDIATE
     jmp HERE
 
-    +BACKLINK
-    !byte 5 | F_IMMEDIATE
-    !text	"while"
+    +BACKLINK "while", 5 | F_IMMEDIATE
     jsr LIT
     !word ZBRANCH
     jsr COMPILE_COMMA
@@ -60,18 +52,14 @@ COMPILE_JMP
     !byte OP_JMP
     jmp CCOMMA
 
-    +BACKLINK
-    !byte 6 | F_IMMEDIATE
-    !text	"repeat"
+    +BACKLINK "repeat", 6 | F_IMMEDIATE
     jsr COMPILE_JMP
     jsr COMMA
     jsr HERE
     jsr SWAP
     jmp STORE
 
-    +BACKLINK
-    !byte	6
-    !text	"branch"
+    +BACKLINK "branch", 6
 BRANCH
     pla
     sta W
@@ -86,9 +74,7 @@ BRANCH
     sta + + 1
 +   jmp PLACEHOLDER_ADDRESS ; replaced with branch destination
 
-    +BACKLINK
-    !byte	7
-    !text	"0branch"
+    +BACKLINK "0branch", 7
 ZBRANCH
     inx
     lda	LSB-1, x
@@ -108,9 +94,7 @@ ZBRANCH
 +   pha
     rts
 
-    +BACKLINK
-    !byte	6 | F_NO_TAIL_CALL_ELIMINATION
-    !text	"unloop"
+    +BACKLINK "unloop",	6 | F_NO_TAIL_CALL_ELIMINATION
     jsr R_TO
     jsr R_TO
     jsr R_TO
@@ -119,9 +103,7 @@ ZBRANCH
     jsr TO_R
     rts
 
-    +BACKLINK
-    !byte	4 | F_IMMEDIATE
-    !text	"exit"
+    +BACKLINK "exit", 4 | F_IMMEDIATE
 EXIT
     lda last_word_no_tail_call_elimination
     bne +

--- a/core.asm
+++ b/core.asm
@@ -23,9 +23,7 @@
 ; DROP SWAP DUP ?DUP OVER 2DUP 1+ 1- + = 0= AND ! @ C! C@ COUNT > < MAX MIN TUCK
 ; >R R> R@ BL PICK DEPTH WITHIN FILL INVERT NEGATE BASE 2*
 
-    +BACKLINK
-    !byte	4 | F_IMMEDIATE
-    !text	"drop"
+    +BACKLINK "drop", 4 | F_IMMEDIATE
 DROP
     lda STATE
     bne +
@@ -34,9 +32,7 @@ DROP
 +   lda #OP_INX
     jmp compile_a
 
-    +BACKLINK
-    !byte	4
-    !text	"swap"
+    +BACKLINK "swap", 4
 SWAP
     ldy	MSB, x
     lda	MSB + 1, x
@@ -49,9 +45,7 @@ SWAP
     sty	LSB + 1, x
     rts
 
-    +BACKLINK
-    !byte	3
-    !text	"dup"
+    +BACKLINK "dup", 3
 DUP
     dex
     lda	MSB + 1, x
@@ -60,18 +54,14 @@ DUP
     sta	LSB, x
     rts
 
-    +BACKLINK
-    !byte 4
-    !text "?dup"
+    +BACKLINK "?dup", 4
 QDUP
     lda MSB, x
     ora LSB, x
     bne DUP
     rts
 
-    +BACKLINK
-    !byte	4
-    !text	"over"
+    +BACKLINK "over", 4
 OVER
     dex
     lda	MSB + 2, x
@@ -80,25 +70,19 @@ OVER
     sta	LSB, x
     rts
 
-    +BACKLINK
-    !byte	4
-    !text	"2dup"
+    +BACKLINK "2dup", 4
 TWODUP
     jsr OVER
     jmp OVER
 
-    +BACKLINK
-    !byte	2
-    !text	"1+"
+    +BACKLINK "1+", 2
 ONEPLUS
     inc LSB, x
     bne +
     inc MSB, x
 +   rts
 
-    +BACKLINK
-    !byte	2
-    !text	"1-"
+    +BACKLINK "1-", 2
 ONEMINUS
     lda LSB, x
     bne +
@@ -106,9 +90,7 @@ ONEMINUS
 +   dec LSB, x
     rts
 
-    +BACKLINK
-    !byte	1
-    !text	"+"
+    +BACKLINK "+", 1
 PLUS
     lda	LSB, x
     clc
@@ -122,9 +104,7 @@ PLUS
     inx
     rts
 
-    +BACKLINK
-    !byte	1
-    !text	"="
+    +BACKLINK "=", 1
 EQUAL
     ldy #0
     lda	LSB, x
@@ -140,9 +120,7 @@ EQUAL
     rts
 
 ; 0=
-    +BACKLINK
-    !byte	2
-    !text	"0="
+    +BACKLINK "0=", 2
 ZEQU
     ldy #0
     lda MSB, x
@@ -154,9 +132,7 @@ ZEQU
     sty LSB, x
     rts
 
-    +BACKLINK
-    !byte	3
-    !text	"and"
+    +BACKLINK "and", 3
     lda	MSB, x
     and MSB + 1, x
     sta MSB + 1, x
@@ -168,9 +144,7 @@ ZEQU
     inx
     rts
 
-    +BACKLINK
-    !byte	1
-    !text	"!"
+    +BACKLINK "!", 1
 STORE
     lda LSB, x
     sta W
@@ -188,9 +162,7 @@ STORE
     inx
     rts
 
-    +BACKLINK
-    !byte	1
-    !text	"@"
+    +BACKLINK "@", 1
 FETCH
     lda LSB,x
     sta W
@@ -205,9 +177,7 @@ FETCH
     sta MSB,x
     rts
 
-    +BACKLINK
-    !byte	2
-    !text	"c!"
+    +BACKLINK "c!", 2
 STOREBYTE
     lda LSB,x
     sta + + 1
@@ -219,9 +189,7 @@ STOREBYTE
     inx
     rts
 
-    +BACKLINK
-    !byte	2
-    !text	"c@"
+    +BACKLINK "c@", 2
 FETCHBYTE
     lda LSB,x
     sta + + 1
@@ -233,18 +201,14 @@ FETCHBYTE
     sta MSB,x
     rts
 
-    +BACKLINK
-    !byte   5
-    !text   "count"
+    +BACKLINK "count", 5
 COUNT
     jsr DUP
     jsr ONEPLUS
     jsr SWAP
     jmp FETCHBYTE
 
-    +BACKLINK
-    !byte 1
-    !text	"<"
+    +BACKLINK "<", 1
 LESS_THAN
     ldy #0
     sec
@@ -261,16 +225,12 @@ LESS_THAN
     sty MSB,x
     rts
 
-    +BACKLINK
-    !byte 1
-    !text	">"
+    +BACKLINK ">", 1
 GREATER_THAN
     jsr SWAP
     jmp LESS_THAN
 
-    +BACKLINK
-    !byte 3
-    !text "max"
+    +BACKLINK "max", 3
 MAX
     jsr TWODUP
     jsr LESS_THAN
@@ -280,9 +240,7 @@ MAX
 +   inx
     rts
 
-    +BACKLINK
-    !byte 3
-    !text "min"
+    +BACKLINK "min", 3
 MIN
     jsr TWODUP
     jsr GREATER_THAN
@@ -292,16 +250,12 @@ MIN
 +   inx
     rts
 
-    +BACKLINK
-    !byte	4
-    !text	"tuck"
-TUCK ; ( x y -- y x y ) 
+    +BACKLINK "tuck", 4
+TUCK ; ( x y -- y x y )
     jsr SWAP
     jmp OVER
 
-    +BACKLINK
-    !byte	2 | F_NO_TAIL_CALL_ELIMINATION
-    !text	">r"
+    +BACKLINK ">r", 2 | F_NO_TAIL_CALL_ELIMINATION
 TO_R
     pla
     sta W
@@ -318,9 +272,7 @@ TO_R
     inx
     jmp (W)
 
-    +BACKLINK
-    !byte	2 | F_NO_TAIL_CALL_ELIMINATION
-    !text	"r>"
+    +BACKLINK "r>", 2 | F_NO_TAIL_CALL_ELIMINATION
 R_TO
     pla
     sta W
@@ -337,9 +289,7 @@ R_TO
     sta MSB,x
     jmp (W)
 
-    +BACKLINK
-    !byte	2 | F_NO_TAIL_CALL_ELIMINATION
-    !text	"r@"
+    +BACKLINK "r@", 2 | F_NO_TAIL_CALL_ELIMINATION
 R_FETCH
     txa
     tsx
@@ -353,15 +303,11 @@ R_FETCH
     sta LSB,x
     rts
 
-    +BACKLINK
-    !byte 2
-    !text	"bl"
+    +BACKLINK "bl", 2
 BL
     +VALUE	K_SPACE
 
-    +BACKLINK
-    !byte   4
-    !text   "pick" ; ( x_u ... x_1 x_0 u -- x_u ... x_1 x_0 x_u )
+    +BACKLINK "pick", 4
     txa
     sta + + 1
     clc
@@ -375,9 +321,7 @@ BL
     sty MSB,x
     rts
 
-    +BACKLINK
-    !byte 5
-    !text	"depth"
+    +BACKLINK "depth", 5
     txa
     eor #$ff
     tay
@@ -388,9 +332,7 @@ BL
     sta MSB,x
     rts
 
-    +BACKLINK
-    !byte 6
-    !text   "within"
+    +BACKLINK "within", 6
 WITHIN ; ( test low high -- flag )
     jsr OVER
     jsr MINUS
@@ -400,9 +342,7 @@ WITHIN ; ( test low high -- flag )
     jmp U_LESS
 
 ; FILL ( start len char -- )
-    +BACKLINK
-    !byte	4
-    !text	"fill"
+    +BACKLINK "fill", 4
 FILL
     lda	LSB, x
     tay
@@ -435,9 +375,7 @@ FILL
     inc	.fdst + 1
     jmp	-
 
-    +BACKLINK
-    !byte 6
-    !text "invert"
+    +BACKLINK "invert", 6
 INVERT
     lda MSB, x
     eor #$ff
@@ -447,23 +385,17 @@ INVERT
     sta LSB,x
     rts
 
-    +BACKLINK
-    !byte 6
-    !text "negate"
+    +BACKLINK "negate", 6
 NEGATE
     jsr INVERT
     jmp ONEPLUS
 
-    +BACKLINK
-    !byte 4
-    !text "base"
+    +BACKLINK "base", 4
     +VALUE	BASE
 BASE
     !word 16
 
-    +BACKLINK
-    !byte   2
-    !text       "2*"
+    +BACKLINK "2*", 2
     asl LSB, x
     rol MSB, x
     rts

--- a/disk.asm
+++ b/disk.asm
@@ -37,18 +37,14 @@ SAVE = $ffd8
 
 ; -----
 
-    +BACKLINK
-    !byte 6
-    !text	"device" ; ( deviceno -- )
+    +BACKLINK "device", 6
     lda LSB,x
     sta $ba
     inx
     rts
 
 ; CLOSEW ( file# -- )
-    +BACKLINK
-    !byte 6
-    !text	"closew"
+    +BACKLINK "closew", 6
 CLOSEW
     lda LSB,x
     sta W
@@ -105,9 +101,7 @@ geof
 ; LOADB ( filenameptr filenamelen dst -- endaddress ) load binary file
 ;  - s" base" 7000 loadb #load file to 7000
 ;  - returns 0 on failure, otherwise address after last written byte
-    +BACKLINK
-    !byte 5
-    !text	"loadb"
+    +BACKLINK "loadb", 5
 LOADB
     txa
     pha
@@ -189,9 +183,7 @@ load_binary_laddr_hi = *+1
 
 ; SAVEB (save binary file)
 ;  - 7000 71ae s" base" saveb #save file from 7000 to 71ae (= the byte AFTER the last byte in the file)
-    +BACKLINK
-    !byte 5
-    !text	"saveb"
+    +BACKLINK "saveb", 5
 SAVEB
     stx W
 
@@ -241,9 +233,7 @@ save_binary_srange_end_hi = *+1
     rts
 
 ; OPENW ( strptr strlen file# ) open file for writing
-    +BACKLINK
-    !byte 5
-    !text	"openw"
+    +BACKLINK "openw", 5
 OPENW
     lda LSB,x
     sta W ; fileno
@@ -280,9 +270,7 @@ OPENW
     jsr CLOSE
     jmp CLRCHN
 
-    +BACKLINK
-    !byte 8
-    !text	"included"
+    +BACKLINK "included", 8
 INCLUDED
     lda	LSB, x
     sta .filelen

--- a/docs/anatomy.tex
+++ b/docs/anatomy.tex
@@ -8,39 +8,32 @@ Let us define a word and see what it gets compiled to.
 : bg $d020 c! ;
 \end{verbatim}
 
-After the word is defined, you can get its start address by \texttt{latest @}, and the contents of bg can be dumped using \texttt{latest @ dump}. Try it, and you will get output like the following:
+Information about the word is split into two areas of memory, the dictionary and the code/data space. Code and data are placed in an upward-growing segment starting at \$801, and the dictionary grows downward from \texttt{top}, default \$6fff. \texttt{latest @} points to the last dictionary record. A dictionary record consists of a counted string with flags, and an execution token (XT).
+
+\section{Dictionary}
+To inspect the dictionary entry, type \texttt{latest @ dump}. You should see something like this:
 
 \begin{alltt}
-4c38  ed 4b 02 42 47 20 cf 0e .k.bg ..
-4c40  20 d0 4c 49 0a ff ff ff  .li....
-4c48  ff ff ff ff ff ff ff ff ........
-4c50  ...
+6228  \textcolor{red}{02 42 47 fd 39} 28 39 01 \textcolor{red}{.bg.9}(9.
+...
 \end{alltt}
 
-Here, we can see that the "bg" word is 14 bytes long and starts at address \$4c38. It contains two parts: Header and code.
-
-\section{Header}
-
-\begin{alltt}
-4c38  \textcolor{red}{ed 4b 02 42 47} 20 cf 0e \textcolor{red}{.k.bg} ..
-4c40  20 d0 4c 49 0a ff ff ff  .li....
-\end{alltt}
-
-The first two bytes contain a back-pointer to the previous word, starting at \$4bed. The next byte, "02", is the length of "bg" name string. After that, the string "bg" follows. (42 = 'b', 47 = 'g')
+The first byte, "02", is the length of "bg" name string. After that, the string "bg" follows. (42 = 'b', 47 = 'g'). The final two bytes contain the execution token of \texttt{bg}, starting at \$39fd.
 
 The name length byte is also used to store special attributes of the word. Bit 7 is "immediate" flag, which means that the word should execute immediately instead of being compiled into word definitions. ("(" is such an example of an immediate word that does not get compiled.) Bit 6 is "hidden" flag, which makes a word unfindable. Bit 5 is the "no-tail-call-elimination" flag, which makes sure that tail call elimination (the practice of replacing jsr/rts with jmp) is not performed if this word is the jsr target. Since bg does not have these flags set, bits 7-5 are all clear.
 
 \section{Code}
+We saw that the "bg" execution token is \$39fd. To inspect the code, type \texttt{\$39fd dump} or \texttt{latest @ >xt dump}.
 
 \begin{alltt}
-4c38  ed 4b 02 42 47 \textcolor{red}{20 cf 0e} .k.bg\textcolor{red}{ ..}
-4c40  \textcolor{red}{20 d0 4c 49 0a ff ff ff  .li..}..
+39fd  \textcolor{red}{20 15 11 20 d0 4c 0e 09  .. Pl..}
+...
 \end{alltt}
 
-The code section contain pure 6502 machine code.
+The code section contains pure 6502 machine code.
 
 \begin{description}
-\item[20 cf 0e ( jsr \$ecf )] \$ecf is the address of the \texttt{lit} code. \texttt{lit} copies the two following bytes to parameter stack.
+\item[20 15 11 ( jsr \$1115 )] \$1115 is the address of the \texttt{lit} code. \texttt{lit} copies the two following bytes to parameter stack.
 \item[20 d0 ( \$d020 )] The parameter to the \texttt{lit} word. When executed, \texttt{lit} will add \$d020 to the parameter stack.
-\item[4c 49 0a ( jmp \$a49 )] \$a49 is the address of the \texttt{c!} code.
+\item[4c 0e 09 ( jmp \$90e )] \$90e is the address of the \texttt{c!} code.
 \end{description}

--- a/docs/memmap.tex
+++ b/docs/memmap.tex
@@ -13,9 +13,9 @@
 \item[\ldots]
 \item[\$801 - \texttt{here}] Forth Kernel followed by code and data space.
 \item[\ldots]
-\item[\texttt{latest} - \texttt{top}] Dictionary. Grows downwards as needed. Default \texttt{top} is \$6fff. 
 \item[\texttt{bufstart} - \texttt{eof}] Editor text buffer. Grows upwards as needed. Default \texttt{bufstart} is \$7000.
 \item[\ldots]
+\item[\texttt{latest @} - \$9fff] Dictionary. Grows downwards as needed.
 \item[\$a000 - \$cbff] Free RAM.
 \item[\$cc00 - \$cfff] Hi-res graphics colors.
 \item[\$d000 - \$dfff] I/O area. 

--- a/docs/memmap.tex
+++ b/docs/memmap.tex
@@ -11,8 +11,9 @@
 \item[\$200 - \$258] Text input buffer.
 \item[\$33C - \$3FB] PAD Scratch pad memory, Cassette Buffer, untouched by DurexForth. 
 \item[\ldots]
-\item[\$801 - \texttt{here}] Forth Kernel followed by dictionary.
+\item[\$801 - \texttt{here}] Forth Kernel followed by code and data space.
 \item[\ldots]
+\item[\texttt{latest} - \texttt{top}] Dictionary. Grows downwards as needed. Default \texttt{top} is \$6fff. 
 \item[\texttt{bufstart} - \texttt{eof}] Editor text buffer. Grows upwards as needed. Default \texttt{bufstart} is \$7000.
 \item[\ldots]
 \item[\$a000 - \$cbff] Free RAM.

--- a/docs/tutorial.tex
+++ b/docs/tutorial.tex
@@ -148,6 +148,8 @@ save-forth @0:durexforth
 
 \subsection{Turn-key Operation}
 
+Durexforth offers utilities to save your program in a turn-key fashion by including the \texttt{turnkey} module.
+
 Programs can be saved in a compacted state using \texttt{save-pack}. These programs are stored with 32 bytes between \texttt{here} and \texttt{latest}. When they are first loaded, they will restore the header space to its original \texttt{top}.
 
 If you have developed a program that has no further need of the interpreter, you can eliminate the dictionary entirely when saving with \texttt{save-prg}. This allows your program to use memory down to \texttt{here} plus 32 bytes for safety. 

--- a/docs/tutorial.tex
+++ b/docs/tutorial.tex
@@ -146,6 +146,12 @@ loadb buf - evaluate ;
 save-forth @0:durexforth
 \end{verbatim}
 
+\subsection{Turn-key Operation}
+
+Programs can be saved in a compacted state using \texttt{save-pack}. These programs are stored with 32 bytes between \texttt{here} and \texttt{latest}. When they are first loaded, they will restore the header space to its original \texttt{top}.
+
+If you have developed a program that has no further need of the interpreter, you can eliminate the dictionary entirely when saving with \texttt{save-prg}. This allows your program to use memory down to \texttt{here} plus 32 bytes for safety. 
+
 \section{How to Learn More}
 
 \subsection{Internet Resources}

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -356,9 +356,20 @@ For more info about number formatting, read Starting Forth!
 
 \begin{description}
 
-\item[latest (variable)] Position of latest defined word.
 
-\item[here (variable)] Write position of the Forth compiler (usually first unused byte of memory). Many C64 assemblers refer to this as program counter or \texttt{*}.
+\item[latest (variable)] Address of latest defined header.
+
+\item[here (value)] Write position of the Forth compiler (usually first unused byte of code space). Many C64 assemblers refer to this as program counter or \texttt{*}.
+
+
+\item[top ( -- addr )] Address of the top of the dictionary, default: \$6fff. 
+
+\item[top! ( addr -- )] Relocates the header space to \texttt{addr}. Example:
+
+\begin{verbatim}
+\ not using the editor, give all memory to dictionary
+$cbff top!
+\end{verbatim}
 
 \item[marker name ( -- )] Creates a word that when called, forgets itself and all words that were defined after it. Example:
 
@@ -366,6 +377,14 @@ For more info about number formatting, read Starting Forth!
 marker forget
 : x ;
 forget
+\end{verbatim}
+
+\item[dowords ( xt -- )] Executes \texttt{xt} for successive headers starting from \texttt{latest}. Each time \texttt{xt} is called, it must consume an argument from the stack and leave behind a truth value. If true (not 0), it will continue to the next header address and call \texttt{xt} again. If false, or if it reaches the end of the dictionary, dowords will return. Example:
+
+\begin{verbatim}
+\ from debug.fs
+: (words) more name>string space 1 ;
+: words ['] (words) dowords ;
 \end{verbatim}
 \end{description}
 
@@ -380,6 +399,8 @@ forget
 \item[saveb ( start end filenameptr filenamelength -- )] Save binary block.
 \item[device ( device\# -- )] Switches the active device.
 \item[save-forth filename ( -- )] Saves the forth to the given filename.
+\item[save-pack filename ( -- )] Saves a compact version of forth to the given filename.
+\item[save-prg filename ( -- )] Saves a forth program with no dictionary to filename.
 \item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards. Example: \texttt{ls \$1:*=p} Load directory, drive 1 only prg files.
 \item[rdir ( addr -- )] Display disk directory previously loaded to addr.
 \end{description}

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -362,15 +362,6 @@ For more info about number formatting, read Starting Forth!
 \item[here (value)] Write position of the Forth compiler (usually first unused byte of code space). Many C64 assemblers refer to this as program counter or \texttt{*}.
 
 
-\item[top ( -- addr )] Address of the top of the dictionary, default: \$6fff. 
-
-\item[top! ( addr -- )] Relocates the header space to \texttt{addr}. Example:
-
-\begin{verbatim}
-\ not using the editor, give all memory to dictionary
-$cbff top!
-\end{verbatim}
-
 \item[marker name ( -- )] Creates a word that when called, forgets itself and all words that were defined after it. Example:
 
 \begin{verbatim}
@@ -379,7 +370,7 @@ marker forget
 forget
 \end{verbatim}
 
-\item[dowords ( xt -- )] Executes \texttt{xt} for successive headers starting from \texttt{latest}. Each time \texttt{xt} is called, it must consume an argument from the stack and leave behind a truth value. If true (not 0), it will continue to the next header address and call \texttt{xt} again. If false, or if it reaches the end of the dictionary, dowords will return. Example:
+\item[dowords ( xt -- )] Remove \texttt{xt} from the stack. Execute \texttt{xt} once for every word in the wordlist, passing the name token \texttt{nt} of the word to \texttt{xt}, until the wordlist is exhausted or until \texttt{xt} returns false. The invoked \texttt{xt} has the stack effect \texttt{( k * x nt -- l * x flag)}. If \texttt{flag} is true, \texttt{dowords} will continue on to the next name, otherwise it will return.
 
 \begin{verbatim}
 \ from debug.fs
@@ -399,8 +390,6 @@ forget
 \item[saveb ( start end filenameptr filenamelength -- )] Save binary block.
 \item[device ( device\# -- )] Switches the active device.
 \item[save-forth filename ( -- )] Saves the forth to the given filename.
-\item[save-pack filename ( -- )] Saves a compact version of forth to the given filename.
-\item[save-prg filename ( -- )] Saves a forth program with no dictionary to filename.
 \item[ls ( -- )] Load disk directory to here and display, with optional drive \# and wildcards. Example: \texttt{ls \$1:*=p} Load directory, drive 1 only prg files.
 \item[rdir ( addr -- )] Display disk directory previously loaded to addr.
 \end{description}
@@ -432,3 +421,21 @@ The \texttt{compat} module contains various words that are not deemed necessary 
 Safe kernel calls may be done from Forth words using \texttt{sys} ( addr -- ). The helper variables \texttt{ar}, \texttt{xr}, \texttt{yr} and \texttt{sr} can be used to set arguments and get results through the a, x, y and status registers.
 
 Example: \texttt{'0' ar c! \$ffd2 sys} calls the CHROUT routine, which prints \texttt{0} on screen.
+
+\section{Turn-key Utilities}
+These words are available by including \texttt{turnkey}.
+\begin{description}
+\item[top ( -- addr )] Address of the top of the dictionary, default: \$9fff. 
+
+\item[top! ( addr -- )] Relocates the dictionary to \texttt{addr}. Example:
+
+\begin{verbatim}
+\ not using $a000 block, give all memory to dictionary
+$cbff top!
+\end{verbatim}
+
+\item[save-pack filename ( -- )] Saves a compact version of forth to the given filename.
+\item[save-prg filename ( -- )] Saves a forth program with no dictionary to filename.
+\end{description}
+
+	Further details on use of these words outlined in the Turn-key Operation section of the tutorial.

--- a/durexforth.asm
+++ b/durexforth.asm
@@ -97,18 +97,18 @@ _START = * + 1
 
 ; ----------- macros
 
-!set TOP = $6fff
-!set DICTOP = TOP
+!set WORDLIST_BASE = $9fff
+!set __LATEST = WORDLIST_BASE
 
 !set BACK = *
-* = DICTOP
+* = __LATEST
 !byte 0
 * = BACK
 
 !macro BACKLINK .name , .namesize {
-    !set DICTOP = DICTOP - 3 - len(.name)
+    !set __LATEST = __LATEST - 3 - len(.name)
     !set .xt = *
-    * = DICTOP
+    * = __LATEST
     !byte .namesize
     !text .name
 	!word .xt
@@ -160,16 +160,13 @@ ONE
 !src "lowercase.asm"
 !src "disk.asm"
 
-    +BACKLINK "top", 3
-    +VALUE  TOP
-
 ; LATEST - points to the most recently defined dictionary word.
 
     +BACKLINK "latest", 6
 LATEST
     +VALUE	_LATEST
 _LATEST
-    !word DICTOP
+    !word __LATEST
 ; ALL CONTENTS BELOW LATEST WILL BE OVERWRITTEN!!!
 
 load_base

--- a/durexforth.asm
+++ b/durexforth.asm
@@ -97,13 +97,22 @@ _START = * + 1
 
 ; ----------- macros
 
-!set LINK = 0
+!set TOP = $6fff
+!set DICTOP = TOP
 
-!macro BACKLINK {
-    ; it's tempting to add the string as a macro parameter,
-    ; but this does not seem to be supported by ACME.
-    !word	LINK
-    !set	LINK = * - 2
+!set BACK = *
+* = DICTOP
+!byte 0
+* = BACK
+
+!macro BACKLINK .name , .namesize {
+    !set DICTOP = DICTOP - 3 - len(.name)
+    !set .xt = *
+    * = DICTOP
+    !byte .namesize
+    !text .name
+	!word .xt
+    * = .xt
 }
 
 !macro VALUE .word {
@@ -114,43 +123,31 @@ _START = * + 1
 
 ; ---------- words
 
-    +BACKLINK
-    !byte 6
-    !text	"pushya"
+    +BACKLINK "pushya", 6
 pushya
     dex
     sta	LSB, x
     sty	MSB, x
     rts
 
-    +BACKLINK
-    !byte 1
-    !text	"0"
+    +BACKLINK "0", 1
 ZERO
     lda	#0
     tay
     jmp pushya
 
-    +BACKLINK
-    !byte 1
-    !text	"1"
+    +BACKLINK "1", 1
 ONE
     +VALUE 1
 
 ; START - points to the code of the startup word.
-    +BACKLINK
-    !byte 5
-    !text	"start"
+    +BACKLINK "start", 5
     +VALUE	_START
 
-    +BACKLINK
-    !byte 3
-    !text	"msb"
+    +BACKLINK "msb", 3
     +VALUE	MSB
 
-    +BACKLINK
-    !byte 3
-    !text	"lsb"
+    +BACKLINK "lsb", 3
     +VALUE	LSB
 
 !src "core.asm"
@@ -163,15 +160,16 @@ ONE
 !src "lowercase.asm"
 !src "disk.asm"
 
+    +BACKLINK "top", 3
+    +VALUE  TOP
+
 ; LATEST - points to the most recently defined dictionary word.
-    +BACKLINK
-    !byte 6
-    !text	"latest"
+
+    +BACKLINK "latest", 6
 LATEST
     +VALUE	_LATEST
 _LATEST
-    !word	LINK
-
+    !word DICTOP
 ; ALL CONTENTS BELOW LATEST WILL BE OVERWRITTEN!!!
 
 load_base

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -106,31 +106,9 @@ then (to) ; immediate
 : 2drop ( a b -- )
 postpone drop postpone drop ; immediate
 
-top value oldtop
-start @ value oldstart
-
-: top! ( addr -- )
-latest @ swap top latest @ - 
-2dup - latest ! 
-over to top swap over - swap 1+ move ;
-
-: restore-forth
-oldtop top! 
-oldstart execute ;
-
-: save-pack ( strptr strlen -- )
-start @ to oldstart
-top to oldtop 
-['] restore-forth start ! 
-here 20 + top latest @ - + top!
-801 top 1+ d word count saveb ;
-
-: save-prg ( strptr strlen -- )
-here 0 , top latest ! top!
-save-pack ;
 
 : save-forth ( strptr strlen -- )
-801 top 1+ d word count saveb ;
+801 $a000 d word count saveb ;
 
 code 2/
 msb lda,x 80 cmp,# msb ror,x lsb ror,x
@@ -220,10 +198,10 @@ postpone then ; immediate
 variable (includes) $1e allot
 (includes) $20 0 fill
 
-: marker top latest @ - here create , , 
+: marker latest @ here create , ,
 (includes) begin dup @ while 2+ repeat , 
 does> dup @ to here
-2+ dup @ top swap - latest ! 
+2+ dup @ latest ! 
 2+ @ 0 swap ! ;
 
 : include parse-name included ;
@@ -241,6 +219,7 @@ marker ---modules---
 .( v..) include v
 
 decimal
+include turnkey 
 cr
 .( cart: )
 $4000 $68 -

--- a/forth_src/test.fs
+++ b/forth_src/test.fs
@@ -1,6 +1,7 @@
 : fakekeys ( n -- ) $c6 c! ;
 
-here latest @
+$cbff top! \ this section compiles past $6fff.
+marker ---test---
 
 .( gfxdemo )
 $b fakekeys \ skips demos
@@ -18,7 +19,8 @@ parse-name mmldemo included
 1 fakekeys \ exits demo
 parse-name spritedemo included
 
-latest ! to here
+---test---
+$6fff top!
 
 : x depth abort" depth" ; x
 

--- a/forth_src/test.fs
+++ b/forth_src/test.fs
@@ -1,6 +1,5 @@
 : fakekeys ( n -- ) $c6 c! ;
 
-$cbff top! \ this section compiles past $6fff.
 marker ---test---
 
 .( gfxdemo )
@@ -20,7 +19,6 @@ parse-name mmldemo included
 parse-name spritedemo included
 
 ---test---
-$6fff top!
 
 : x depth abort" depth" ; x
 

--- a/forth_src/turnkey.fs
+++ b/forth_src/turnkey.fs
@@ -1,0 +1,27 @@
+marker ---turnkey---
+
+$9fff value top
+$9fff value oldtop
+start @ value oldstart
+
+: top! ( addr -- )
+latest @ swap top latest @ - 
+2dup - latest ! over to top
+swap over - swap 1+ move ;
+
+: restore-forth
+oldtop top! 
+oldstart
+---turnkey---
+execute ;
+
+: save-pack ( strptr strlen -- )
+start @ to oldstart
+top to oldtop 
+['] restore-forth start ! 
+here $20 + top latest @ - + top!
+$801 top 1+ $d word count saveb ;
+
+: save-prg ( strptr strlen -- )
+here 0 , top latest ! top!
+save-pack ;

--- a/forth_src/viceutil.fs
+++ b/forth_src/viceutil.fs
@@ -9,6 +9,7 @@ Then, load the file from VICE
 monitor using 'll "words"'
 )
 
+\ TODO broken until TRAVERSE-WORDLIST
 : dump-labels base @ hex
 s" words" 1 openw
 latest @ begin ?dup while

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -733,15 +733,15 @@ OLD_BASE = * + 1
     sta .xt + 1
     inx
     lda _LATEST
-    sta .dowords_nt
+    sta .dowords_nametoken
     lda _LATEST + 1
-    sta .dowords_nt + 1
+    sta .dowords_nametoken + 1
 
 .dowords_lambda
     dex
-    lda .dowords_nt
+    lda .dowords_nametoken
     sta LSB, x
-    lda .dowords_nt + 1
+    lda .dowords_nametoken + 1
     sta MSB, x
 .xt = * + 1
     jsr PLACEHOLDER_ADDRESS
@@ -750,21 +750,21 @@ OLD_BASE = * + 1
     bne +
 -   rts
 +   ldy #0
-    lda .dowords_nt
+    lda .dowords_nametoken
     sta W
-    lda .dowords_nt + 1
+    lda .dowords_nametoken + 1
     sta W + 1
     lda (W), y
     beq -
     and #STRLEN_MASK
     clc
     adc #3 ; guaranteed carry clear
-    adc .dowords_nt
-    sta .dowords_nt
-    lda .dowords_nt + 1
+    adc .dowords_nametoken
+    sta .dowords_nametoken
+    lda .dowords_nametoken + 1
     adc #0
-    sta .dowords_nt + 1
+    sta .dowords_nametoken + 1
     jmp .dowords_lambda
 ; using a word here in case the lambda trashes Ws
-.dowords_nt
+.dowords_nametoken
     !word 0

--- a/io.asm
+++ b/io.asm
@@ -22,24 +22,18 @@
 
 ; TYPE EMIT PAGE KEY? KEY REFILL SOURCE SOURCE-ID >IN GETC CHAR
 
-    +BACKLINK
-    !byte	4
-    !text	"emit"
+    +BACKLINK "emit", 4
 EMIT
     lda	LSB, x
     inx
     jmp	PUTCHR
 
-    +BACKLINK
-    !byte   4
-    !text   "page"
+    +BACKLINK "page", 4
 PAGE
     lda #K_CLRSCR
     jmp PUTCHR
 
-    +BACKLINK
-    !byte 4
-    !text	"type"
+    +BACKLINK "type", 4
 TYPE ; ( caddr u -- )
     lda #0 ; quote mode off
     sta $d4
@@ -56,9 +50,7 @@ TYPE ; ( caddr u -- )
     jsr SLASH_STRING
     jmp -
 
-    +BACKLINK
-    !byte	4
-    !text	"key?"
+    +BACKLINK "key?", 4
     lda $c6 ; Number of characters in keyboard buffer
     beq +
 .pushtrue
@@ -66,9 +58,7 @@ TYPE ; ( caddr u -- )
 +   tay
     jmp pushya
 
-    +BACKLINK
-    !byte	3
-    !text	"key"
+    +BACKLINK "key", 3
 -   lda $c6
     beq -
     stx W
@@ -77,9 +67,7 @@ TYPE ; ( caddr u -- )
     ldy #0
     jmp pushya
 
-    +BACKLINK
-    !byte	6
-    !text	"refill" ; ( -- )
+    +BACKLINK "refill", 6
 REFILL
 
 READ_EOF = * + 1
@@ -178,9 +166,7 @@ GET_CHAR_FROM_TIB
     inc TO_IN_W + 1
 +   rts
 
-    +BACKLINK
-    !byte 6
-    !text	"source"
+    +BACKLINK "source", 6
 SOURCE
     dex
     dex
@@ -199,9 +185,7 @@ TIB_PTR
 TIB_SIZE
     !word 0
 
-    +BACKLINK
-    !byte 9
-    !text	"source-id"
+    +BACKLINK "source-id", 9
 SOURCE_ID_LSB = * + 1
 SOURCE_ID_MSB = * + 3
     ; -1 : string (via evaluate)
@@ -209,17 +193,13 @@ SOURCE_ID_MSB = * + 3
     ; 1+ : file id
     +VALUE	0
 
-    +BACKLINK
-    !byte	3
-    !text	">in"
+    +BACKLINK ">in", 3
 TO_IN
     +VALUE TO_IN_W
 TO_IN_W
     !word 0
 
-    +BACKLINK
-    !byte	4
-    !text	"getc"
+    +BACKLINK "getc", 4
     jsr GET_CHAR_FROM_TIB
     bne +
     jsr REFILL
@@ -227,9 +207,7 @@ TO_IN_W
 +   ldy #0
     jmp pushya
 
-    +BACKLINK
-    !byte	4
-    !text	"char"
+    +BACKLINK "char", 4
 CHAR ; ( name -- char )
 -   jsr PARSE_NAME
     lda LSB,x

--- a/math.asm
+++ b/math.asm
@@ -25,9 +25,7 @@
 
 ; U< - UM* UM/MOD M+
 
-    +BACKLINK
-    !byte	2
-    !text	"u<"
+    +BACKLINK "u<", 2
 U_LESS
     ldy #0
     lda	MSB, x
@@ -46,9 +44,7 @@ U_LESS
     sty	LSB, x
     rts
 
-    +BACKLINK
-    !byte	1
-    !text	"-"
+    +BACKLINK "-", 1
 MINUS
     lda	LSB + 1, x
     sec
@@ -64,9 +60,7 @@ MINUS
 
 product = W
 
-    +BACKLINK
-    !byte	3
-    !text	"um*"
+    +BACKLINK "um*", 3
 ; wastes W, W2, y
 U_M_STAR
     lda #$00
@@ -102,9 +96,7 @@ rotate_r
     sta	MSB, x
     rts
 
-    +BACKLINK
-	!byte	6
-	!text	"um/mod"
+    +BACKLINK "um/mod", 6
 ; ( lsw msw divisor -- rem quot )
         N = W
         SEC
@@ -151,9 +143,7 @@ oflo:   LDA     #$FF    ; If overflow or /0 condition found,
 end:    INX
         jmp SWAP
 
-    +BACKLINK
-	!byte	2
-	!text	"m+" ; ( d1 u -- d2 )
+    +BACKLINK "m+", 2
     ldy #0
     lda MSB,x
     bpl +

--- a/move.asm
+++ b/move.asm
@@ -33,7 +33,7 @@ CMOVE_BACK
     clc
     adc LEN + 1
     sta DST + 1
-    
+
     ldy LEN
     bne .entry
     beq .pagesizecopy
@@ -104,9 +104,7 @@ cmove_done
 	tax
 	rts
 
-    +BACKLINK
-    !byte	4
-    !text	"move" ; ( src dst u -- )
+    +BACKLINK "move", 4
 MOVE
     jsr TO_R
     jsr TWODUP


### PR DESCRIPTION
Here is an even smaller version of the split dictionary changes.  It is functional except for the cartridge, which requires 212 bytes to be removed from the dictionary.

I have taken care to try to create the smallest possible set of diffs, hence the least number of changes.  There are also changelog and documentation fixes.

I'm not going to close the other one in case you prefer.  Again, I am not in a hurry and do not this change in master any time soon.