### PR TITLE
FIND-NAME now return a name token per proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Dictionary restructured, now header and code data are split.
  - Header data is not a linked list, and grows downward from $9fff. Record structure: `len_flags | str | xt`
  - Prompt displays `ful` when there is less than 256 bytes of dictionary space left.
+ - FIND-NAME now returns a name token per the standard proposal
 ### Added
  - RDIR will display directory formatted data anywhere in memory.
  - PAD Scratch pad memory set to cassette buffer. Untouched by DurexForth

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -336,7 +336,7 @@ For more info about number formatting, read Starting Forth!
 \begin{description}
 \item[' xxx ( -- addr )] Find execution token of word \texttt{xxx}.
 \item[find ( cstr -- cstr 0 $\vert$ xt -1 $\vert$ xt 1 )] Find the definition named in the counted string cstr. If the definition is not found, return cstr and 0, otherwise return the execution token. If the definition is immediate, also return 1, otherwise also return -1.
-\item[find-name ( caddr u -- caddr u 0 $\vert$ xt -1 $\vert$ xt 1 )] Like \texttt{find}, except that it does not require a counted string.
+\item[find-name ( caddr u -- 0 $\vert$ nt )] Get the name token (dictionary pointer) of word named in the string, or 0 if the word is not found.
 \item[execute ( xt -- )] Execute the execution token on top of stack.
 \item[$>$xt ( addr -- xt )] Get execution token of word at adress \texttt{addr}.
 


### PR DESCRIPTION
The rationale for this change is this:

The new dictionary structure eliminates the relationship between an XT and its header.  It's no longer a question of simple arithmetic to get one from the other.  DOWORDS exists for scanning the headers, yes, but it's essentially replicating the work FIND-NAME did in the first place, and it's complex and slow.

This change increases the binary size slightly, but reduces the code size and increases the speed of any word that seeks to edit the dictionary. NAME>STRING and >XT would be meaningful outside of a DOWORDS lambda.