### PR TITLE
Shrunk V with DEFER. Fixed bufstart in memory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Prompt displays `ful` when there is less than 256 bytes of dictionary space left.
  - FIND-NAME now returns a name token per the standard proposal
  - DEFER and associated words moved to defer.fs, included in base distribution.
+ - V internal words hidden, BUFSTART no longer variable, fixed at $7000.
 ### Added
  - RDIR will display directory formatted data anywhere in memory.
  - PAD Scratch pad memory set to cassette buffer. Untouched by DurexForth

--- a/docs/editor.tex
+++ b/docs/editor.tex
@@ -2,7 +2,7 @@
 
 The editor is a vi clone. Launch it by entering \texttt{v foo} in the interpreter (\texttt{foo} being the file you want to edit). You may also enter \texttt{v} without argument to create an unnamed buffer. For more info about vi style editing, see \href{http://www.vim.org}{the Vim web site}.
 
-The position of the editor buffer is controlled by the variable \texttt{bufstart}. The default address is \$7000.
+The position of the editor buffer is \$7000.
 
 \section{Key Presses}
 

--- a/docs/memmap.tex
+++ b/docs/memmap.tex
@@ -13,7 +13,7 @@
 \item[\ldots]
 \item[\$801 - \texttt{here}] Forth Kernel followed by code and data space.
 \item[\ldots]
-\item[\texttt{bufstart} - \texttt{eof}] Editor text buffer. Grows upwards as needed. Default \texttt{bufstart} is \$7000.
+\item[\$7000 - \texttt{eof}] Editor text buffer. Grows upwards as needed.
 \item[\ldots]
 \item[\texttt{latest @} - \$9fff] Dictionary. Grows downwards as needed.
 \item[\$a000 - \$cbff] Free RAM.

--- a/forth_src/v.fs
+++ b/forth_src/v.fs
@@ -1,5 +1,9 @@
 marker ---editor---
 
+defer v
+
+latest @ \ begin hiding words
+
 $d value lf
 
 $7001 value bufstart
@@ -543,7 +547,7 @@ eof @ c@ abort" eof"
 curlinestart @ bufstart eof @ within
 0= abort" cl" again ;
 
-: v
+:noname
 \ modifies kernal to change kbd prefs
 ram-kernal $eaea @ $8ca <> if
 rom-kernal
@@ -568,4 +572,6 @@ reset-buffer
 rom-kernal bufstart loadb
 ?dup 0= if reset-buffer else
 eof ! 0 eof @ c! then
-else drop then main-loop ;
+else drop then main-loop ; is v
+
+latest ! \ end hiding words


### PR DESCRIPTION
There were no instructions as to how to change `bufstart` properly, so I
didn't bother exporting it.