### PR TITLE
Added HIDE to defer.fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - SAVE-PRG removes the dictionary and saves the program
  - TOP returns the address of the last byte of the header structure. The value at this address will always be 0.
  - TOP! can be used to specify the position of header data.
+ - HIDE removes words from the dictionary.
 ### Fixed
  - V did not compile in DECIMAL mode.
  - V long line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - SAVE-PRG removes the dictionary and saves the program
  - TOP returns the address of the last byte of the header structure. The value at this address will always be 0.
  - TOP! can be used to specify the position of header data.
- - HIDE removes words from the dictionary.
+ - HIDE removes a word from the word list, while leaving its definition in place.
 ### Fixed
  - V did not compile in DECIMAL mode.
  - V long line

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -147,6 +147,7 @@ Copies a region of memory \texttt{len} bytes long, starting at \texttt{src}, to 
 \item[create xxx/does$>$] Create a word creating word \texttt{xxx} with custom behavior
 specified after \texttt{does$>$}. For further description, see "Starting Forth."
 \item[state ( -- addr)] addr is the address of a cell containing the compilation-state flag. It is 1 when compiling, otherwise 0.
+\item[hide xxx] Removes \texttt{xxx} from the word list, while leaving its definition in place.
 
 \end{description}
 

--- a/forth_src/defer.fs
+++ b/forth_src/defer.fs
@@ -5,3 +5,10 @@ does> @ execute ;
 : is state @ if
 postpone ['] postpone defer!
 else ' defer! then ; immediate
+: hide ( word -- )
+parse-name find-name ?dup if
+dup latest @ - ( nt size )
+>r c@ $1f and 3 + ( off )
+latest @ swap over +  ( srca dsta )
+dup latest !
+r> move then ;

--- a/forth_src/defer.fs
+++ b/forth_src/defer.fs
@@ -5,7 +5,7 @@ does> @ execute ;
 : is state @ if
 postpone ['] postpone defer!
 else ' defer! then ; immediate
-: hide ( word -- )
+: hide ( "name" -- )
 parse-name find-name ?dup if
 dup latest @ - ( nt size )
 >r c@ $1f and 3 + ( off )


### PR DESCRIPTION
There's probably a better place to put it, but `HIDE` bridges an important
gap between using deferred words to hide words en masse and just needing
to delete a single private word.

It is an uncomplicated way to remove any kind of word (deferred variables / values are a bit messy?) from the dictionary with no overhead penalty.