### PR TITLE
V Improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - HIDE removes a word from the word list, while leaving its definition in place.
  - DEFINE assigns HERE to a word in the word list and begins compilation.
  - DEFCODE does the same as DEFINE, but begins a CODE: segment instead.
+ - V commands: A, R, +, -, HOME, e, C, D, s, S, H, L, M, ^w
 ### Fixed
  - V did not compile in DECIMAL mode.
  - V long line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - HIDE removes a word from the word list, while leaving its definition in place.
  - DEFINE assigns HERE to a word in the word list and begins compilation.
  - DEFCODE does the same as DEFINE, but begins a CODE: segment instead.
- - V commands: A, R, +, -, HOME, e, C, D, s, S, H, L, M, ^w
+ - V commands: A, R, +, -, HOME, e, C, D, s, S, H, L, M, ^w, f, F
 ### Fixed
  - V did not compile in DECIMAL mode.
  - V long line

--- a/docs/editor.tex
+++ b/docs/editor.tex
@@ -32,6 +32,8 @@ At startup, the editor is in command mode. The following commands enter insert m
 \item[b] Go to previous word.
 \item[w] Go to next word.
 \item[e] Go to end of word.
+\item[fx] Find char \texttt{x} forward.
+\item[Fx] Find char \texttt{x} backward.
 \item[0 | Home] Go to line start.
 \item[\$] Go to line end.
 \item[g] Go to start of file.

--- a/docs/editor.tex
+++ b/docs/editor.tex
@@ -7,10 +7,15 @@ The position of the editor buffer is \$7000.
 \section{Key Presses}
 
 \subsection{Inserting Text}
-Following commands enter insert mode. Insert mode allows you to insert text. It can be exited by pressing $\leftarrow$.
+At startup, the editor is in command mode. The following commands enter insert mode, which allows you to enter text into the editor buffer. You can return to command mode with $\leftarrow$.
 \begin{description}
 \item[i] Insert text.
+\item[R] Replace text.
 \item[a] Append text.
+\item[A] Append text at end of line.
+\item[C] Change rest of line.
+\item[S] Substitute line.
+\item[s] Substitute character.
 \item[o] Open new line after cursor line.
 \item[O] Open new line on cursor line.
 \item[cw] Change word.
@@ -20,14 +25,20 @@ Following commands enter insert mode. Insert mode allows you to insert text. It 
 \begin{description}
 \item[hjkl] Cursor left, down, up, right.
 \item[Cursor Keys] ...also work fine.
+\item[-] Scroll 1 line up.
+\item[+] Scroll 1 line down.
 \item[Ctrl+u] Half page up.
 \item[Ctrl+d] Half page down.
 \item[b] Go to previous word.
 \item[w] Go to next word.
-\item[0] Go to line start.
+\item[e] Go to end of word.
+\item[0 | Home] Go to line start.
 \item[\$] Go to line end.
 \item[g] Go to start of file.
 \item[G] Go to end of file.
+\item[H] Go to home window line.
+\item[L] Go to last window line.
+\item[M] Go to middle window line.
 \item[/\{string\}] Search forward for the next occurrence of the string.
 \item[*] Search forward for the next occurrence of the word under the cursor.
 \item[n] Repeat the latest search.
@@ -52,6 +63,7 @@ After quitting, the editor can be re-opened by entering \texttt{v}, and it will 
 \item[X] Backspace-delete character.
 \item[dw] Delete word.
 \item[dd] Cut line.
+\item[D] Delete rest of line.
 \item[yy] Yank (copy) line.
 \item[p] Paste line below cursor position.
 \item[P] Paste line on cursor position.

--- a/forth_src/v.fs
+++ b/forth_src/v.fs
@@ -479,6 +479,17 @@ ins-start ;
 
 : change-line del-to-eol ins-start ;
 
+: findchar ( dir )
+curx @ swap key begin 
+over editpos + c@ eol= invert while
+over curx +! dup editpos c@ = if
+2drop drop exit then repeat
+2drop curx ! ;
+
+: findchar-fwd 1 findchar ;
+
+: findchar-back -1 findchar ; 
+
 \ key handler table
 \ semi-ordered by most-used
 header keytab
@@ -528,6 +539,8 @@ $17 c, ' del-word , \ ctrl+w
 'H' c, ' go-home ,
 'L' c, ' go-last ,
 'M' c, ' go-mid ,
+'f' c, ' findchar-fwd ,
+'F' c, ' findchar-back ,
 0 c,
 \ --- key handlers end
 

--- a/forth_src/v.fs
+++ b/forth_src/v.fs
@@ -296,7 +296,7 @@ lf of ins-char cur-down sol show-page
 endof 
 insert 2 = if at-eol if
 ins-start ins-char else repl-char 
-curx @ 1+ curx ! then 
+1 curx +! then 
 else ins-char then endcase ;
 
 : del-word


### PR DESCRIPTION
Added keystroke commands: A, R, +, -, HOME, e, C, D, s, S, H, L, M, ^w, f, F

The command set is now much closer to vi.

Refactored keystroke functions for size now that `:noname` is automatic inside a hidden block.

245 bytes free on the cart.  Net 285 byte growth of `v`.