### PR TITLE
Hid private word HASH from require.fs

### DIFF
--- a/forth_src/require.fs
+++ b/forth_src/require.fs
@@ -17,3 +17,5 @@ i @ 0= if included leave then
 2dup hash i @ = if 2drop leave then
 2 +loop ;
 : require parse-name required ;
+
+hide hash


### PR DESCRIPTION
I didn't notice this one in the cleanup.