### PR TITLE
gfx: PEEK should switch out Kernal automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - V long line
  - Documented SEE concatenating subsequent :NONAME
  - SP-X! had bug in most significant bit
+ - GFX: PEEK fetched bitmap pixels from ROM instead of RAM
 
 ## [2.0.0] - 2020-03-22
 

--- a/forth_src/gfx.fs
+++ b/forth_src/gfx.fs
@@ -109,7 +109,7 @@ kernal-out
 kernal-in ;
 
 : peek ( x y -- b )
-blitloc c@ and ;
+blitloc kernal-out c@ kernal-in and ;
 
 variable dy
 variable sy variable sx
@@ -496,15 +496,14 @@ jmp, \ recurse
 : paint ( x y -- )
 2dup c8 < 0= swap 140 < 0= or
 if 2drop exit then
-kernal-out
-2dup peek if 2drop kernal-in exit then
-
+2dup peek if 2drop exit then
 here stk !
 \ push y x x 1
 2dup swap dup 1 spush
 \ push y+1 x x -1
 1+ swap dup ffff spush
 
+kernal-out
 begin here stk @ < while
 spop dy @ + \ y
 


### PR DESCRIPTION
`PEEK` is documented as a graphics word that can be used without any special preparation, but it assumed that the Kernal had already been switched out, causing incorrect results unless the Kernal had already been switched out before it was invoked.

For example:
`$10 clrcol 3 3 plot 3 3 peek .` should output `16`, but instead we get `0`

The only use of `PEEK` that I could find was in `PAINT` inside `gfx.fs` itself; I have updated `PAINT` to work with the fixed `PEEK`.

Alternatively, we could simply document that `PEEK` must be used in conjunction with  `KERNAL-OUT` and `KERNAL-IN`, but changing `PEEK`'s behavior seems more user-friendly :)