### PR TITLE
Fixes #302 and #303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - V long line
  - Documented SEE concatenating subsequent :NONAME
  - SP-X! had bug in most significant bit
+ - RESTORE-FORTH did not restore start vector
+ - SAVE-PACK did not leave the system usable
+ - SAVE-PRG now points LATEST to a constant 0
 
 ## [2.0.0] - 2020-03-22
 

--- a/docs/tutorial.tex
+++ b/docs/tutorial.tex
@@ -151,11 +151,18 @@ save-forth @0:durexforth
 
 \subsection{Turn-key Operation}
 
-Durexforth offers utilities to save your program in a turn-key fashion by including the \texttt{turnkey} module.
+Durexforth offers utilities to save your program in a turn-key fashion by including the \texttt{turnkey} module once the program is ready to be saved.
 
 Programs can be saved in a compacted state using \texttt{save-pack}. These programs are stored with 32 bytes between \texttt{here} and \texttt{latest}. When they are first loaded, they will restore the header space to its original \texttt{top}.
 
-If you have developed a program that has no further need of the interpreter, you can eliminate the dictionary entirely when saving with \texttt{save-prg}. This allows your program to use memory down to \texttt{here} plus 32 bytes for safety. 
+If you have developed a program that has no further need of the interpreter, you can eliminate the dictionary headers entirely when saving with \texttt{save-prg}. This allows your program to use memory down to \texttt{here} plus 32 bytes for safety.
+
+After either of these words have saved the file to disk, they will restore forth to the unpacked state, and strip the \texttt{turnkey} module from the dictionary. This allows you to continue to use forth interactively in the case of \texttt{save-pack}. As \texttt{save-prg} has stripped the dictionary headers from the system, it will no longer be usable. If you wish to test your program after saving, you can compile a call to \texttt{save-prg} instead:
+\begin{verbatim}
+: build save-prg mydemo start @ execute ;
+build
+\end{verbatim}
+This will simulate the start-up sequence after saving the packed program.
 
 \section{How to Learn More}
 

--- a/forth_src/turnkey.fs
+++ b/forth_src/turnkey.fs
@@ -11,21 +11,26 @@ swap over - swap 1+ move ;
 
 : restore-forth
 oldtop top! 
-oldstart
----turnkey---
-execute ;
+oldstart start !
+---turnkey--- ;
+
+: newstart
+restore-forth
+start @ execute ;
 
 : save-pack ( strptr strlen -- )
 start @ to oldstart
 top to oldtop 
-['] restore-forth start ! 
+['] newstart start ! 
 here $20 + top latest - + top!
-$801 top 1+ $d word count saveb ;
+$801 top 1+ $d word count saveb
+restore-forth ;
 
 : save-prg ( strptr strlen -- )
-here 0 , top to latest top!
+top to latest ['] 0 1+ top! \ constant 0
 save-pack ;
 
 hide oldtop
 hide oldstart
 hide restore-forth
+hide newstart


### PR DESCRIPTION
Adjustments to `turnkey` words to produce a better user experience.

Fixes #302 by restoring forth after `save-pack`
Fixes #303 by locating `latest` at a constant 0 byte
Clarifies some documentation