### PR TITLE
Fix #309 by updating dump-labels to use dowords

### DIFF
--- a/forth_src/viceutil.fs
+++ b/forth_src/viceutil.fs
@@ -9,12 +9,12 @@ Then, load the file from VICE
 monitor using 'll "words"'
 )
 
-\ TODO broken until TRAVERSE-WORDLIST
-: dump-labels base @ hex
-s" words" 1 openw
-latest @ begin ?dup while
-." al " dup >xt . '.' emit
-dup name>string
+\ print a VICE label definition for a
+\ given nametoken. returns 1, for use
+\ with dowords
+: (label) ( nametoken -- 1 )
+." al " dup >xt u. '.' emit
+name>string
 over + swap do i c@ 
 dup 'a' < over 'z' > or if case
 \ escape forbidden chars
@@ -51,4 +51,9 @@ dup 'a' < over 'z' > or if case
 '"' of ." :quote:" endof
 dup emit endcase
 else emit then loop
-$a emit @ repeat 1 closew base ! ;
+$a emit 1 ;
+
+: dump-labels base @ >r hex
+s" words" 1 openw
+['] (label) dowords
+1 closew r> base ! ;

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -766,6 +766,16 @@ OLD_BASE = * + 1
     sta .dowords_nametoken + 1
 
 .dowords_lambda
+    lda .dowords_nametoken
+    sta W
+    lda .dowords_nametoken + 1
+    sta W + 1
+    ldy #0
+    lda (W), y
+    bne +
+-   rts
++   and #STRLEN_MASK
+    pha
     dex
     lda .dowords_nametoken
     sta LSB, x
@@ -775,16 +785,8 @@ OLD_BASE = * + 1
     jsr PLACEHOLDER_ADDRESS
     inx
     lda LSB-1, x
-    bne +
--   rts
-+   ldy #0
-    lda .dowords_nametoken
-    sta W
-    lda .dowords_nametoken + 1
-    sta W + 1
-    lda (W), y
     beq -
-    and #STRLEN_MASK
+    pla
     clc
     adc #3 ; guaranteed carry clear
     adc .dowords_nametoken

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -784,9 +784,9 @@ OLD_BASE = * + 1
 .xt = * + 1
     jsr PLACEHOLDER_ADDRESS
     inx
-    lda LSB-1, x
-    beq -
     pla
+    ldy LSB-1, x
+    beq -
     clc
     adc #3 ; guaranteed carry clear
     adc .dowords_nametoken


### PR DESCRIPTION
Fixes #309. Also fixes a `dowords` bug that caused the lambda to be called on the invalid nametoken at the end of the dictionary.