### PR TITLE
Update interpreter.asm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+ - Restore key is clean NMI, Run/Stop Restore to QUIT
  - LATEST changed from VARIABLE to VALUE
  - FIND-NAME now returns a name token per the standard proposal
  - Dictionary restructured, now header and code data are split.
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Words for file and device IO in OPEN: and IO:
  - Utility for drive status and DOS commands in DOS:
 ### Fixed
+ - RS232: NMI vector was redirected to QUIT
  - SP-X! had bug in most significant bit
  - GFX: PEEK fetched bitmap pixels from ROM instead of RAM
  - V did not compile in DECIMAL mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Words for file and device IO in OPEN: and IO:
  - Utility for drive status and DOS commands in DOS:
 ### Fixed
+ - BRK vector was redirected to QUIT 
  - RS232: NMI vector was redirected to QUIT
  - SP-X! had bug in most significant bit
  - GFX: PEEK fetched bitmap pixels from ROM instead of RAM

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -43,16 +43,13 @@ stop_restore
 	cmp	#$7f		; compare with [stp] down
 	        		; if not [stp] or not just [stp] exit
     bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-    pla
-    pla
-    tax
-    jmp QUIT
+    jsr $f333       ; set screen, keyboard, devices untalk, unlisten
 
 brk_handler
    pla
    pla
    tax              ; restore xr for QUIT
-   jmp skip_clall
+   jmp QUIT
    
 quit_reset  ; execute once at start
     sei
@@ -118,10 +115,6 @@ keep_nmi
 
     +BACKLINK "quit", 4
 QUIT
-    jsr $ffe7       ; CLALL. Clear file table; call CLRCHN.
-    
-skip_clall
-
     jsr keep_nmi
 
     ; resets the return stack

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -107,7 +107,7 @@ keep_nmi
     stx     SOURCE_ID_MSB
     stx     SAVE_INPUT_STACK_DEPTH
     stx     READ_EOF
-    jsr $ffe7       ; CLALL. Clear file table; call CLRCHN.
+    jsr     $ffcc   ; CLRCHN
     pla
     tax
     rts

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -40,6 +40,8 @@ stop_restore
    jsr	$f6bc		; increment real time clock
    jsr	$ffe1		; scan stop key 
    bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
+   
+brk_handler
    pla
    pla
    tax              ; restore xr for QUIT
@@ -51,6 +53,11 @@ quit_reset  ; execute once at start
     sta $318
     lda #>restore_handler
     sta $319
+
+    lda #<brk_handler
+    sta $316
+    lda #>brk_handler
+    sta $317
     
 keep_nmi
     cli ; still have to

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -43,13 +43,16 @@ stop_restore
 	cmp	#$7f		; compare with [stp] down
 	        		; if not [stp] or not just [stp] exit
     bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-    jsr $f333       ; set screen, keyboard, devices untalk, unlisten
+    pla
+    pla
+    tax
+    jmp QUIT
 
 brk_handler
    pla
    pla
    tax              ; restore xr for QUIT
-   jmp QUIT
+   jmp skip_clall
    
 quit_reset  ; execute once at start
     sei
@@ -115,6 +118,10 @@ keep_nmi
 
     +BACKLINK "quit", 4
 QUIT
+    jsr $ffe7       ; CLALL. Clear file table; call CLRCHN.
+    
+skip_clall
+
     jsr keep_nmi
 
     ; resets the return stack

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -23,9 +23,25 @@
 ; QUIT INTERPRET FIND FIND-NAME >CFA PARSE-NAME WORD EXECUTE EVALUATE ' ABORT /STRING
 
 restore_handler
-    cli
-    jmp QUIT
+   pha				; save a
+   txa				; copy x
+   pha				; save x
+   tya				; copy y
+   pha				; save y
+   lda	#$7f	    ; disable all interrupts
+   sta	$dd0d       ; 
+   ldy	$dd0d       ; save cia 2 icr
+   bpl stop_restore ; if high bit not set
 
+kernal_nmi
+   jmp $fe72
+
+stop_restore
+   jsr	$f6bc		; increment real time clock
+   jsr	$ffe1		; scan stop key
+   bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
+   
+   jmp QUIT
 quit_reset
     sei
     lda #<restore_handler

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -51,8 +51,10 @@ quit_reset  ; execute once at start
     sta $318
     lda #>restore_handler
     sta $319
-    cli
+    
 keep_nmi
+    cli ; still have to
+
     ; lores
     lda #$9b
     sta $d011

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -43,8 +43,8 @@ stop_restore
 	cmp	#$7f		; compare with [stp] down
 	        		; if not [stp] or not just [stp] exit
     bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-    jsr $ffe7       ; CLALL. Clear file table; call CLRCHN
-    
+    jsr $f333       ; set screen, keyboard, devices untalk, unlisten
+
 brk_handler
    pla
    pla
@@ -108,6 +108,7 @@ keep_nmi
     stx     SOURCE_ID_MSB
     stx     SAVE_INPUT_STACK_DEPTH
     stx     READ_EOF
+    jsr     $ffcc   ; CLRCHN
     pla
     tax
     rts

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -43,7 +43,7 @@ stop_restore
 	cmp	#$7f		; compare with [stp] down
 	        		; if not [stp] or not just [stp] exit
     bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-
+    jsr $f333       ; set screen, keyboard, devices untalk, unlisten
 
 brk_handler
    pla

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -43,8 +43,7 @@ stop_restore
 	cmp	#$7f		; compare with [stp] down
 	        		; if not [stp] or not just [stp] exit
     bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-    jsr $f333       ; set screen, keyboard, devices untalk, unlisten
-
+    
 brk_handler
    pla
    pla
@@ -108,7 +107,7 @@ keep_nmi
     stx     SOURCE_ID_MSB
     stx     SAVE_INPUT_STACK_DEPTH
     stx     READ_EOF
-    jsr     $ffcc   ; CLRCHN
+    jsr $ffe7       ; CLALL. Clear file table; call CLRCHN.
     pla
     tax
     rts

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -38,18 +38,18 @@ kernal_nmi
 
 stop_restore
    jsr	$f6bc		; increment real time clock
-   jsr	$ffe1		; scan stop key
+   jsr	$ffe1		; scan stop key 
    bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
    
    jmp QUIT
-quit_reset
+quit_reset  ; execute once at start
     sei
     lda #<restore_handler
     sta $318
     lda #>restore_handler
     sta $319
     cli
-
+keep_nmi
     ; lores
     lda #$9b
     sta $d011
@@ -99,7 +99,7 @@ quit_reset
 
     +BACKLINK "quit", 4
 QUIT
-    jsr quit_reset
+    jsr keep_nmi
 
     ; resets the return stack
     txa

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -50,7 +50,7 @@ brk_handler
    tax              ; restore xr for QUIT
    jmp QUIT
    
-quit_reset  ; execute once at start
+quit_reset
     sei
     lda #<restore_handler
     sta $318
@@ -62,8 +62,7 @@ quit_reset  ; execute once at start
     lda #>brk_handler
     sta $317
     
-keep_nmi
-    cli ; still have to
+   cli ; still have to
 
     ; lores
     lda #$9b
@@ -114,7 +113,7 @@ keep_nmi
 
     +BACKLINK "quit", 4
 QUIT
-    jsr keep_nmi
+    jsr quit_reset
 
     ; resets the return stack
     txa

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -37,14 +37,10 @@ kernal_nmi
    jmp $fe72
 
 stop_restore
-    jsr	$f6bc		; increment real time clock
-                    ; scan stop key 
-   	lda	$91 		; read the stop key column
-	cmp	#$7f		; compare with [stp] down
-	        		; if not [stp] or not just [stp] exit
-    bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-
-
+   jsr	$f6bc		; increment real time clock
+   jsr	$ffe1		; scan stop key 
+   bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
+   
 brk_handler
    pla
    pla

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -51,10 +51,8 @@ quit_reset  ; execute once at start
     sta $318
     lda #>restore_handler
     sta $319
-    
+    cli
 keep_nmi
-    cli ; still have to
-
     ; lores
     lda #$9b
     sta $d011

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -43,8 +43,8 @@ stop_restore
 	cmp	#$7f		; compare with [stp] down
 	        		; if not [stp] or not just [stp] exit
     bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-    jsr $f333       ; set screen, keyboard, devices untalk, unlisten
-
+    jsr $ffe7       ; CLALL. Clear file table; call CLRCHN
+    
 brk_handler
    pla
    pla
@@ -108,7 +108,6 @@ keep_nmi
     stx     SOURCE_ID_MSB
     stx     SAVE_INPUT_STACK_DEPTH
     stx     READ_EOF
-    jsr     $ffcc   ; CLRCHN
     pla
     tax
     rts

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -37,10 +37,14 @@ kernal_nmi
    jmp $fe72
 
 stop_restore
-   jsr	$f6bc		; increment real time clock
-   jsr	$ffe1		; scan stop key 
-   bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-   
+    jsr	$f6bc		; increment real time clock
+                    ; scan stop key 
+   	lda	$91 		; read the stop key column
+	cmp	#$7f		; compare with [stp] down
+	        		; if not [stp] or not just [stp] exit
+    bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
+
+
 brk_handler
    pla
    pla

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -40,8 +40,11 @@ stop_restore
    jsr	$f6bc		; increment real time clock
    jsr	$ffe1		; scan stop key 
    bne	kernal_nmi	; if not [stop] restore registers and exit interrupt
-   
+   pla
+   pla
+   tax              ; restore xr for QUIT
    jmp QUIT
+   
 quit_reset  ; execute once at start
     sei
     lda #<restore_handler


### PR DESCRIPTION
This avoids rom cart init- passes through non-CIA NMI's (Restore) silently, and executes quit at run/stop Restore.
Replaces restore_handler entirely in interpreter.asm  YaY ! 