### PR TITLE
include Git hash in d64 ; calculate TAG variables once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 C1541   = c1541
 AS = acme
-TAG = `git describe --tags --abbrev=0 || svnversion --no-newline`
-TAG_DEPLOY_DOT = `git describe --tags --abbrev=0 --dirty=-M`
-TAG_DEPLOY = `git describe --tags --abbrev=0 --dirty=_M | tr _. -_`
+
+TAG := $(shell git describe --tags --abbrev=0 || svnversion --no-newline)
+TAG_DEPLOY_DOT := $(shell git describe --tags --abbrev=0 --dirty=-m)
+TAG_DEPLOY := $(shell git describe --tags --abbrev=0 --dirty=_M | tr _. -_)
+GIT_HASH := $(shell git rev-parse --short HEAD)
 
 SRC_DIR = forth_src
 SRC_NAMES = base debug v asm gfx gfxdemo rnd sin ls turtle fractals \
@@ -40,6 +42,7 @@ durexforth.d64: durexforth.prg Makefile ext/petcom $(SRCS)
 	$(C1541) -attach $@ -write durexforth.prg durexforth # > /dev/null
 	$(C1541) -attach $@ -write $(EMPTY_FILE) $(SEPARATOR_NAME1) # > /dev/null
 	$(C1541) -attach $@ -write $(EMPTY_FILE) $(TAG_DEPLOY_DOT),s # > /dev/null
+	$(C1541) -attach $@ -write $(EMPTY_FILE) '  '$(GIT_HASH),s # > /dev/null
 	$(C1541) -attach $@ -write $(EMPTY_FILE) $(SEPARATOR_NAME2) # > /dev/null
 # $(C1541) -attach $@ -write debug.bak
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ C1541   = c1541
 AS = acme
 
 TAG := $(shell git describe --tags --abbrev=0 || svnversion --no-newline)
-TAG_DEPLOY_DOT := $(shell git describe --tags --abbrev=0 --dirty=-m)
+TAG_DEPLOY_DOT := $(shell git describe --tags --long --dirty=_m | sed 's/-g[0-9a-f]\+//' | tr _- -.)
 TAG_DEPLOY := $(shell git describe --tags --abbrev=0 --dirty=_M | tr _. -_)
 GIT_HASH := $(shell git rev-parse --short HEAD)
 


### PR DESCRIPTION
+ include Git hash in d64 after version string (for traceability)
+ use lower case 'm' in d64 (was 'M') for warning that repo files were modified
  as d64 was generated (looks better when listing disk in upper case mode)
+ calculate TAG variables only once using shell command
  (previous form was just text in a variable that was not executed
  until later during each command which obfuscates the flow)