### PR TITLE
fix bug with load 'base' fixed filename length.

### DIFF
--- a/durexforth.asm
+++ b/durexforth.asm
@@ -180,7 +180,7 @@ load_base
     sta LSB+1, x
     lda #>basename
     sta MSB+1, x
-    lda #4
+    lda #(basename_end - basename)
     sta LSB,x
     jsr INCLUDED
     jmp interpret_loop


### PR DESCRIPTION
Load fails if string at 'basename' is not exactly 4 characters.