### PR TITLE
change signature of OPEN/CHKIN/CHKOUT/IOABORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - OPEN/CHKIN/CHKOUT no longer returns a file number.
+ - IOABORT no longer accepts a file number.
 
 ### Fixed
  - LOADB/SAVEB could change active device.

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -290,7 +290,7 @@ endcase
 
     Typical use: \texttt{: x ... test abort" error" ... ;}
 
-\item[quit] Enters an endless loop where DurexForth interprets Forth commands from the keyboard. The word is named "quit" since it can be used to quit a program. It also does cleanup tasks like resetting input.
+\item[quit] Enters an endless loop where DurexForth interprets Forth commands from the keyboard. The word is named "quit" since it can be used to quit a program. It also does cleanup tasks like resetting I/O.
 
 \end{description}
 
@@ -425,14 +425,14 @@ Words for sending DOS commands to drives and reading drive status are available 
 For more advanced uses, words corresponding to the standard Commodore Kernal IO routines are available by including \texttt{io}.
 
 \begin{description}
-    \item[open ( filenameptr filenamelength file\# secondary-addr -- file\# ioresult )] Open a logical file.
-    \item[chkin ( file\# -- file\# ioresult )] Use a logical file as input device.
-    \item[chkout ( file\# -- file\# ioresult )] Use a logical file as output device.
+    \item[open ( filenameptr filenamelength file\# secondary-addr -- ioresult )] Open a logical file.
+    \item[chkin ( file\# -- ioresult )] Use a logical file as input device.
+    \item[chkout ( file\# -- ioresult )] Use a logical file as output device.
     \item[clrchn ( -- )] Resets input and output to the keyboard and screen.
     \item[close ( file\# -- )] Close a logical file.
     \item[readst ( -- status )] Returns the status of the last IO operation. For serial-bus devices, \texttt{\$01} = write timeout, \texttt{\$02} = read timeout, \texttt{\$40} = end of file (EOI), \texttt{\$80} = device not present.
     \item[chrin ( -- char)] Reads a character from the current input device.
-    \item[ioabort ( file\# ioresult -- )] Handle error conditions for \texttt{open}, \texttt{chkin} or \texttt{chkout}. On error, close the file and abort with an explanatory error message.
+    \item[ioabort ( ioresult -- )] Handles error conditions for \texttt{open}, \texttt{chkin} or \texttt{chkout}. On failure, print error message and abort.
 \end{description}
 
 As per the underlying Kernal routines, \texttt{chrin} does not check for end-of-file or any other error condition. \texttt{readst} should be called to ensure that the returned character is valid.

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -432,7 +432,7 @@ For more advanced uses, words corresponding to the standard Commodore Kernal IO 
     \item[close ( file\# -- )] Close a logical file.
     \item[readst ( -- status )] Returns the status of the last IO operation. For serial-bus devices, \texttt{\$01} = write timeout, \texttt{\$02} = read timeout, \texttt{\$40} = end of file (EOI), \texttt{\$80} = device not present.
     \item[chrin ( -- char)] Reads a character from the current input device.
-    \item[ioabort ( ioresult -- )] Handles error conditions for \texttt{open}, \texttt{chkin} or \texttt{chkout}. On failure, print error message and abort.
+    \item[ioabort ( ioresult -- )] Handles error conditions for \texttt{open}, \texttt{chkin} and \texttt{chkout}. On failure, print error message and abort.
 \end{description}
 
 As per the underlying Kernal routines, \texttt{chrin} does not check for end-of-file or any other error condition. \texttt{readst} should be called to ensure that the returned character is valid.

--- a/forth_src/io.fs
+++ b/forth_src/io.fs
@@ -1,16 +1,14 @@
-require open
-
 \ Use logical file as input device
 \ ioresult is 0 on success, kernal
 \ error # on failure.
-code chkin ( file# -- file# ioresult )
+code chkin ( file# -- ioresult )
 w stx,
 lsb lda,x tax, \ x = file#
 $ffc6 jsr, \ CHKIN
 +branch bcs, \ carry set = error
 0 lda,# \ A is only valid on error
 :+
-w ldx, dex,
+w ldx,
 lsb sta,x
 0 lda,# msb sta,x
 ;code
@@ -18,14 +16,14 @@ lsb sta,x
 \ Use logical file as output device
 \ ioresult is 0 on success, kernal
 \ error # on failure.
-code chkout ( file# -- file# ioresult )
+code chkout ( file# -- ioresult )
 w stx,
 lsb lda,x tax, \ x = file#
 $ffc9 jsr, \ CHKOUT
 +branch bcs, \ carry set = error
 0 lda,# \ A is only valid on error
 :+
-w ldx, dex,
+w ldx,
 lsb sta,x
 0 lda,# msb sta,x
 ;code
@@ -55,7 +53,7 @@ w ldx, lsb sta,x
 \ close, and chkin. If ioresult is
 \ nonzero, print error message and
 \ abort.
-: ioabort ( file# ioresult -- )
+: ioabort ( ioresult -- )
 ?dup if rvs case
 1 of ." too many files" endof
 2 of ." file# in use" endof
@@ -66,5 +64,4 @@ w ldx, lsb sta,x
 7 of ." not output file" endof
 8 of ." missing filename" endof
 9 of ." illegal device #" endof
-." io err " endcase
-cr abort else drop then ;
+." io err" endcase cr abort then ;

--- a/forth_src/open.fs
+++ b/forth_src/open.fs
@@ -1,8 +1,8 @@
 \ Open a logical file
 \ ioresult is 0 on success, kernal
 \ error # on failure.
-( nameaddr namelen file# sa -- 
-  file# ioresult )
+( nameaddr namelen file# sa --
+  ioresult )
 code open
 w stx,
 lsb 1+ lda,x \ a = file #
@@ -21,10 +21,9 @@ $ffc0 jsr, \ OPEN
 0 lda,# \ A is only valid on error
 :+
 w ldx,
-inx, inx,
+inx, inx, inx,
 lsb sta,x
-lsb 1- lda,x lsb 1+ sta,x
-0 lda,# msb sta,x msb 1+ sta,x
+0 lda,# msb sta,x
 ;code
 
 \ Close a logical file


### PR DESCRIPTION
There is no longer any reason to pass file# into IOABORT, since ABORT now closes all open files.

wdyt @Whammo ?