### PR TITLE
Convert IOABORT to assembly, use it in INCLUDE

### DIFF
--- a/.lvimrc
+++ b/.lvimrc
@@ -1,5 +1,5 @@
 map <F4> :wall!<CR>:make all<CR>
-map <F5> :!x64.exe durexforth.d64 &<CR>
+map <F5> :!x64sc.exe durexforth.d64 &<CR>
 
 set nomodeline
 

--- a/disk.asm
+++ b/disk.asm
@@ -272,7 +272,9 @@ INCLUDED
     jsr	SETLFS
     jsr	OPEN
     bcc	+
-    jmp ABORT
+    ldx #-1
+    sta LSB,x
+    jmp IOABORT
 +
     ldx	SOURCE_ID_LSB ; file number
     jsr	CHKIN

--- a/disk.asm
+++ b/disk.asm
@@ -272,7 +272,9 @@ INCLUDED
     jsr	SETLFS
     jsr	OPEN
     bcc	+
-    ldx #-1
+    pla
+    tax
+    dex
     sta LSB,x
     jmp IOABORT
 +

--- a/disk.asm
+++ b/disk.asm
@@ -272,9 +272,7 @@ INCLUDED
     jsr	SETLFS
     jsr	OPEN
     bcc	+
-    pla
-    tax
-    dex
+    ldx #-1
     sta LSB,x
     jmp IOABORT
 +

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -1,5 +1,4 @@
 : 2+ 1+ 1+ ;
-: cr d emit ;
 : nip swap drop ;
 : jmp, 4c c, ;
 : ['] ' [ ' literal compile, ]
@@ -179,8 +178,6 @@ r> 0< if swap negate swap then ;
 : .s depth begin ?dup while
 dup pick . 1- repeat ;
 
-code rvs 12 lda,# ffd2 jsr, ;code
-
 : abort"
 postpone if
 postpone rvs
@@ -214,7 +211,6 @@ marker ---modules---
 .( ls..) include ls
 .( require..) include require
 .( open..) include open
-.( io..) include io
 .( v..) include v
 
 decimal

--- a/forth_src/io.fs
+++ b/forth_src/io.fs
@@ -48,15 +48,3 @@ dex, w stx, 0 lda,# msb sta,x
 $ffcf jsr, \ CHRIN
 w ldx, lsb sta,x
 ;code
-
-\ handle errors returned by open,
-\ close, and chkin. If ioresult is
-\ nonzero, print error message and
-\ abort.
-: ioabort  ( ioresult -- )
-?dup 0= if exit then rvs
-dup 9 > if ." io err" else
-$37 1 c! 1- 2* $a328 + @
-begin dup c@ dup $80 and 0= while
-emit 1+ repeat $80 - emit
-then cr abort ;

--- a/io.asm
+++ b/io.asm
@@ -316,6 +316,7 @@ IOABORT ; ( ioresult -- )
     jsr CHROUT
     jsr CHROUT
     jmp .cr_abort
+
 .print_basic_error
     lda #$37
     sta 1

--- a/io.asm
+++ b/io.asm
@@ -300,8 +300,7 @@ IOABORT ; ( ioresult -- )
     ora MSB-1,x
     bne +
     rts
-+   jsr RVS
-    lda LSB-1,x
++   lda LSB-1,x
     cmp #10
     bcc .print_basic_error
 
@@ -329,6 +328,9 @@ IOABORT ; ( ioresult -- )
     sta W+1
 
 .print_msb_terminated_string
+    jsr CLRCHN
+    jsr RVS
+
     ldy #0
 -   lda (W),y
     pha

--- a/io.asm
+++ b/io.asm
@@ -296,15 +296,15 @@ RESTORE_INPUT
     +BACKLINK "ioabort", 7
 IOABORT ; ( ioresult -- )
     inx
+    lda MSB-1,x
+    bne .print_ioerr
     lda LSB-1,x
-    ora MSB-1,x
     bne +
     rts
-+   lda LSB-1,x
-    cmp #10
++   cmp #10
     bcc .print_basic_error
 
-    ; prints "ioerr"
+.print_ioerr
     lda #<.ioerr
     sta W
     lda #>.ioerr

--- a/io.asm
+++ b/io.asm
@@ -309,7 +309,7 @@ IOABORT ; ( ioresult -- )
     lda #<.ioerr
     sta W
     lda #>.ioerr
-    lda W+1
+    sta W+1
     jmp .print_msb_terminated_string
 
 .ioerr

--- a/io.asm
+++ b/io.asm
@@ -306,18 +306,15 @@ IOABORT ; ( ioresult -- )
     bcc .print_basic_error
 
     ; prints "ioerr"
-    lda #'i'
-    jsr CHROUT
-    lda #'o'
-    jsr CHROUT
-    lda #' '
-    jsr CHROUT
-    lda #'e'
-    jsr CHROUT
-    lda #'r'
-    jsr CHROUT
-    jsr CHROUT
-    jmp .cr_abort
+    lda #<.ioerr
+    sta W
+    lda #>.ioerr
+    lda W+1
+    jmp .print_msb_terminated_string
+
+.ioerr
+    !text "ioer"
+    !byte 'r'|$80
 
 .print_basic_error
     lda #$37
@@ -331,6 +328,7 @@ IOABORT ; ( ioresult -- )
     lda $a327,x
     sta W+1
 
+.print_msb_terminated_string
     ldy #0
 -   lda (W),y
     pha

--- a/io.asm
+++ b/io.asm
@@ -304,6 +304,8 @@ IOABORT ; ( ioresult -- )
     lda LSB-1,x
     cmp #10
     bcc .print_basic_error
+
+    ; prints "ioerr"
     lda #'i'
     jsr CHROUT
     lda #'o'


### PR DESCRIPTION
 @Whammo - what do you think?
I like this, because now e.g. "10 DEVICE INCLUDE FOO" will give an error message "DEVICE NOT PRESENT".
This could be very helpful.

_errorchread is still used after failed READST - I'm not sure, but right now I'd guess it's not a bad thing.

Probably some improvements should also be done for LOADB/SAVEB, I will have to think about that tomorrow. It's a bit unclear how errors should be managed for those cases. Maybe they should return an `ioresult`, or maybe something else should be done, don't know yet.