### PR TITLE
make sure crt is in 16k mode before doing rom to ram copy

### DIFF
--- a/cart.asm
+++ b/cart.asm
@@ -37,6 +37,7 @@ warmstart
     sta $ba ; last device
     lda #$1
     sta $8d
+    sta $de00 ; make sure we are in 16k mode (doesn't matter what we write, just a write does the trick)
     ldy #0
 -
     lda ($8b),y


### PR DESCRIPTION
Fixes issue with U64/UII+, and due to how the Simon's BASIC crt works, should not interfer with other platforms (verified on vice)

The fix enables 16k cartridge mode by doing a write to $de00.