### PR TITLE
A much complicated OPEN for device 2 weirdness.

### DIFF
--- a/forth_src/open.fs
+++ b/forth_src/open.fs
@@ -22,7 +22,7 @@ $ba ldx, 2 cpx,#
 '2' @@ bne,  \ rs232 ?
 $f0 cmp,     \ rs232 go on that error
 '3' @@ bne, 
-'1' @: clc,  \ carry clear or rs232 = $f0
+'1' @:       \ carry clear or rs232 = $f0
 0 lda,#      \ A is only valid on error
 '2' @:       \ not rs232 and carry set
 '3' @:       \ carry set and rs232 <> $f0

--- a/forth_src/open.fs
+++ b/forth_src/open.fs
@@ -16,10 +16,16 @@ msb 3 + ldy,x
 lsb 3 + lda,x tax, pla, \ xy = nameptr
 $ffbd jsr, \ SETNAM
 
-$ffc0 jsr, \ OPEN
-+branch bcs, \ carry set = error
-0 lda,# \ A is only valid on error
-:+
+$ffc0 jsr,   \ OPEN
+'1' @@ bcc,  \ carry set = error or rs232
+$ba ldx, 2 cpx,# 
+'2' @@ bne,  \ rs232 ?
+$f0 cmp,     \ rs232 go on that error
+'3' @@ bne, 
+'1' @: clc,  \ carry clear or rs232 = $f0
+0 lda,#      \ A is only valid on error
+'2' @:       \ not rs232 and carry set
+'3' @:       \ carry set and rs232 <> $f0
 w ldx,
 inx, inx, inx,
 lsb sta,x


### PR DESCRIPTION
 If carry set, check if it's device 2. if it is, and  a contains 240, we're go, ~~Clear carry and~~ zero accumulator
 If carry set and it's device 2 and A doesn't contain 240 it's a file or device open error,
 
If carry clear it's not rs232 OPEN
```asm
.C:3b96  20 C0 FF    JSR $FFC0
.C:3b99  90 0A       BCC $3BA5
.C:3b9b  A6 BA       LDX $BA
.C:3b9d  E0 02       CPX #$02
.C:3b9f  D0 07       BNE $3BA8
.C:3ba1  C5 F0       CMP $F0
.C:3ba3  D0 03       BNE $3BA8
.C:3ba5  18          CLC
.C:3ba6  A9 00       LDA #$00
.C:3ba8  A6 8B       LDX $8B
```