### PR TITLE
Adds GETIN to io.fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Moved and shrunk PAD area.
  - Sped up signed multiply and divide
  - Data stack effects of :/;/:NONAME/DEFINE. Starting with 2.0.0, :/:NONAME/DEFINE would put a value on the data stack, to be later consumed by ;. This is no longer the case.
+### Added
+ - GETIN in IO:
 ### Fixed
  - LOADB/SAVEB could change active device.
  - IOABORT did not print all error messages.

--- a/forth_src/io.fs
+++ b/forth_src/io.fs
@@ -48,3 +48,11 @@ dex, w stx, 0 lda,# msb sta,x
 $ffcf jsr, \ CHRIN
 w ldx, lsb sta,x
 ;code
+
+\ Get a byte or a null from
+\ keyboard buffer or rs232
+code getin ( -- chr )
+dex, w stx, 0 lda,# msb sta,x
+$ffe4 jsr, \ GETIN
+w ldx, lsb sta,x
+;code


### PR DESCRIPTION
 GETIN is required for RS232 receive and is useful for input from the keyboard buffer.