### PR TITLE
Double literals, M*/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Data stack effects of :/;/:NONAME/DEFINE. Starting with 2.0.0, :/:NONAME/DEFINE would put a value on the data stack, to be later consumed by ;. This is no longer the case.
 ### Added
  - GETIN in IO:
+ - M*/
+ - Literal doubles with a trailing period, e.g.: -100000.
 ### Fixed
  - LOADB/SAVEB could change active device.
  - IOABORT did not print all error messages.

--- a/math.asm
+++ b/math.asm
@@ -296,20 +296,20 @@ product_hi
     !word 0
     !word 0
 
-;    ( d1 u1 u2 -- d2 )
+;    ( d1 n1 +n2 -- d2 )
     +BACKLINK "m*/", 3
-; wastes W, W2, y, W3 if u2 != 1 or -1
+; wastes W, W2, y, W3 if +n2 != 1
 M_STAR_SLASH
     lda MSB + 2,x
-    eor MSB,x
+    eor MSB + 1,x
     sta .negateprod
-    jsr ABS
     inx
+    jsr ABS
     inx
     jsr DABS
     dex
     dex
-    lda MSB, x      ; skip division if divisor = 1 or -1
+    lda MSB, x      ; skip division if divisor = 1
     bne +           ; saves W3 from being wasted if division not required
     lda LSB, x
     cmp #1

--- a/math.asm
+++ b/math.asm
@@ -24,6 +24,7 @@
 ; http://6502.org/source/integers/ummodfix/ummodfix.htm
 
 ; U< - UM* UM/MOD M+ INVERT NEGATE ABS * DNEGATE M* 0< S>D FM/MOD /MOD UD/MOD
+; DABS M*/
 
     +BACKLINK "u<", 2
 U_LESS
@@ -208,7 +209,6 @@ DABS_STAR           ; ( n1 n2 -- ud1 )
     rts
 
     +BACKLINK "m*", 2
-M_STAR
     jsr DABS_STAR
     bmi DNEGATE
     rts
@@ -411,7 +411,7 @@ UT_DIV_MOD ; (ut1 u2 -- urem udquot )
     jsr UM_DIV_MOD	; divide the highest word
     ; ( u urem uquot )
     lda LSB,x
-    pha           ; throw the result away
+    pha
     lda MSB,x
     pha		        ; cache the high word of quotient
 
@@ -426,5 +426,3 @@ UT_DIV_MOD ; (ut1 u2 -- urem udquot )
     pla
     sta LSB,x
     rts
-
-


### PR DESCRIPTION
This patch does 2 things:
1. Implement `M*/`
2. Implement double literals with a trailing period

Discussion of this feature at #433 


`M*/` is required to achieve the double literal because base conversion must use doubles as input to multiplication, and this is the only forth operator to do this.  Internally it's a 32*32=64 bit multiplier with a 48/16=32 bit divider.

There is no performance impact to the math.asm changes: `ud/mod`'s changes come out in the wash when integrated with `ut/mod`, an unlisted function that accepts a triple (48-bit) dividend and a 16-bit divisor.  It is effectively the exact same routine as before, as the cascading divison required a leading 0 to divide the top word anyways.

`READ_NUMBER` is slower, owing to the 32-bit multiplication, but now able to return a double.

The code is obviously larger.

This commit updates the changelog and has cleared `include test`.