### PR TITLE
Optimize EXIT, C!, C@ and 0=

### DIFF
--- a/control.asm
+++ b/control.asm
@@ -113,13 +113,13 @@ EXIT
     lda HERE_LSB
     sec
     sbc #3
-    sta .instr_ptr
+    tay
     lda HERE_MSB
     sbc #0
     sta .instr_ptr + 1
     lda #OP_JMP
 .instr_ptr = * + 1
-    sta PLACEHOLDER_ADDRESS ; replaced with instruction pointer
+    sta PLACEHOLDER_ADDRESS,y ; replaced with instruction pointer
     rts
 +
     lda #OP_RTS

--- a/core.asm
+++ b/core.asm
@@ -123,9 +123,9 @@ EQUAL
     +BACKLINK "0=", 2
 ZEQU
     ldy #0
-    lda MSB, x
-    bne +
     lda LSB, x
+    bne +
+    lda MSB, x
     bne +
     dey
 +   sty MSB, x
@@ -179,23 +179,21 @@ FETCH
 
     +BACKLINK "c!", 2
 STOREBYTE
-    lda LSB,x
-    sta + + 1
+    ldy LSB,x
     lda MSB,x
     sta + + 2
     lda	LSB+1,x
-+   sta PLACEHOLDER_ADDRESS ; replaced with addr
++   sta PLACEHOLDER_ADDRESS,y ; replaced with addr
     inx
     inx
     rts
 
     +BACKLINK "c@", 2
 FETCHBYTE
-    lda LSB,x
-    sta + + 1
+    ldy LSB,x
     lda MSB,x
     sta + + 2
-+   lda PLACEHOLDER_ADDRESS ; replaced with addr
++   lda PLACEHOLDER_ADDRESS,y ; replaced with addr
     sta LSB,x
     lda #0
     sta MSB,x

--- a/durexforth.asm
+++ b/durexforth.asm
@@ -68,7 +68,8 @@ K_CLRSCR = $93
 K_SPACE = ' '
 
 ; PLACEHOLDER_ADDRESS instances are overwritten using self-modifying code.
-PLACEHOLDER_ADDRESS = $1234
+; It must end in 00 for situations where the Y register is used as the LSB of the address.
+PLACEHOLDER_ADDRESS = $1200
 
 !ct pet
 


### PR DESCRIPTION
Hi!

I found few places where I could squeeze some more bytes or cycles.

EXIT:
2 bytes, 1 cycle saved.

C!:

3 bytes, 3 cycles saved.

C@:

3 bytes, 3 cycles saved.

0=
For numbers 1-$ff, 6 cycles saved.
For numbers $100, $200,... $ff00, 6 cycles more.
Since the former are much more common than the latter, it's statistically a net saving.
Other numbers unaffected.
