### PR TITLE
max S" string length 255 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - An improved SEE which should decode most colon words.
 ### Changed
+ - S" max string length is reduced to 255 characters.
  - #> (the pictured numeric output string buffer) now uses its own buffer, separate from HERE.
  - Do not print "ok" while compiling. Makes it easier to re-enter multi-line word definitions in interpreter.
 

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -23,7 +23,7 @@ latestxt compile, ; immediate
 : 0<> ( x -- flag ) 0= 0= ;
 
 : lits ( -- addr len )
-r> 1+ dup 1+ swap c@ 2dup + 1- >r ;
+r> 1+ count 2dup + 1- >r ;
 
 : s" ( -- addr len )
 postpone lits here 0 c, 0

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -23,13 +23,13 @@ latestxt compile, ; immediate
 : 0<> ( x -- flag ) 0= 0= ;
 
 : lits ( -- addr len )
-r> 1+ dup 2+ swap @ 2dup + 1- >r ;
+r> 1+ dup 1+ swap c@ 2dup + 1- >r ;
 
 : s" ( -- addr len )
-postpone lits here 0 , 0
+postpone lits here 0 c, 0
 begin getc dup '"' <>
 while c, 1+ repeat
-drop swap ! ; immediate
+drop swap c! ; immediate
 
 : ." postpone s" postpone type
 ; immediate

--- a/forth_src/mmldemo.fs
+++ b/forth_src/mmldemo.fs
@@ -1,5 +1,5 @@
 require mml
-cr .( Frere Jaques) 
+cr .( Frere Jaques)
 : frere-jaques
 s" o3l4fgaffgafab->c&c<ab->c&cl8cdc<b-
 l4af>l8cdc<b-l4affcf&ffcf&f"
@@ -8,9 +8,19 @@ c<b-l4af>l8cdc<b-l4affcf&ffcf&f"
 s" " play-mml ;
 frere-jaques
 
-cr .( Sarias Song) 
+\ l" is like s", but supports strings
+\ longer than 255 bytes.
+: litl ( -- addr len )
+r> 1+ dup 2+ swap @ 2dup + 1- >r ;
+: l" ( -- addr len )
+postpone litl here 0 , 0
+begin getc dup '"' <>
+while c, 1+ repeat
+drop swap ! ; immediate
+
+cr .( Sarias Song)
 : sarias-song
-s" l16o3f8o4crcrcro3f8o4crcrcro3f8o4crc
+l" l16o3f8o4crcrcro3f8o4crcrcro3f8o4crc
 rcro3f8o4crcro3cre8o4crcrcro3e8o4
 crcrcro3e8o4crcrcro3e8o4crcro3c8f8o4crc
 rcro3f8o4crcrcro3f8o4crcrcro3f8o4

--- a/forth_src/see.fs
+++ b/forth_src/see.fs
@@ -47,7 +47,7 @@ u> 0= if \ back
 #until type! then 5+ ;
 
 : skip-lits ( addr -- addr )
-3+ dup @ + 2+ ;
+3+ dup c@ + 1+ ;
 
 : scan-loop ( addr -- addr+5 )
 \ correct #else to #leave
@@ -112,7 +112,7 @@ endcase leave then
 
 : print-lits ( addr -- addr )
 's' emit '"' emit space
-5+ dup 2 - @ begin ?dup while
+4+ dup 1- c@ begin ?dup while
 over c@ emit 1 /string repeat
 '"' emit space ;
 


### PR DESCRIPTION
Make LITS use a byte for string length, thus reducing maximum string length to 255 bytes. Closes #463 

Good: Saves one byte per string definition. Allows reuse of COUNT. Makes behavior more consistent.
Bad: Breaking change. Broke MML examples.