### PR TITLE
Standard-conforming REFILL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - An improved SEE which should decode most colon words.
 ### Changed
  - S" max string length is reduced to 255 characters.
+ - Changed REFILL to Forth standard behavior: Fill the input buffer from the input source, returning true if successful.
  - #> (the pictured numeric output string buffer) now uses its own buffer, separate from HERE.
  - Do not print "ok" while compiling. Makes it easier to re-enter multi-line word definitions in interpreter.
 

--- a/compiler.asm
+++ b/compiler.asm
@@ -167,7 +167,7 @@ HEADER
 -   jsr PARSE_NAME
     lda LSB,x
     bne +
-    jsr REFILL
+    jsr GETLINE
     jmp -
 +
     ; update dictionary pointer

--- a/disk.asm
+++ b/disk.asm
@@ -300,7 +300,7 @@ INCLUDED
     tax
 
     ; interpret until EOF
--   jsr REFILL
+-   jsr GETLINE
     lda READ_EOF
     bne +
     jsr interpret_tib

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -268,7 +268,7 @@ endcase
 
 \item[\index{$>$in}$>$in ( -- addr)] Gives the address of a cell containing the offset in characters from the start of the input buffer to the start of the parse area.
 
-\item[\index{refill}refill ( -- flag )] Attempts to fill the input buffer from the input source, returning a true flag if successful.
+\item[\index{refill}refill ( -- flag )] Attempts to fill the input buffer from the input source, returning true if successful.
 
 \item[\index{source}source ( -- caddr u)] Gives the address of, and number of characters in, the input buffer.
 \item[\index{source-id}source-id ( -- n )] Returns 0 if current input is keyboard, -1 if it is a string from \texttt{evaluate}, or the current file id.

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -268,7 +268,7 @@ endcase
 
 \item[\index{$>$in}$>$in ( -- addr)] Gives the address of a cell containing the offset in characters from the start of the input buffer to the start of the parse area.
 
-\item[\index{refill}refill ( -- )] Attempts to fill the input buffer from the input source.
+\item[\index{refill}refill ( -- flag )] Attempts to fill the input buffer from the input source, returning a true flag if successful. If there is no input available from the current input source, return false. When the input source is a string from \texttt{evaluate}, return false and perform no other action.
 
 \item[\index{source}source ( -- caddr u)] Gives the address of, and number of characters in, the input buffer.
 \item[\index{source-id}source-id ( -- n )] Returns 0 if current input is keyboard, -1 if it is a string from \texttt{evaluate}, or the current file id.

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -268,7 +268,7 @@ endcase
 
 \item[\index{$>$in}$>$in ( -- addr)] Gives the address of a cell containing the offset in characters from the start of the input buffer to the start of the parse area.
 
-\item[\index{refill}refill ( -- flag )] Attempts to fill the input buffer from the input source, returning a true flag if successful. If there is no input available from the current input source, return false. When the input source is a string from \texttt{evaluate}, return false and perform no other action.
+\item[\index{refill}refill ( -- flag )] Attempts to fill the input buffer from the input source, returning a true flag if successful.
 
 \item[\index{source}source ( -- caddr u)] Gives the address of, and number of characters in, the input buffer.
 \item[\index{source-id}source-id ( -- n )] Returns 0 if current input is keyboard, -1 if it is a string from \texttt{evaluate}, or the current file id.

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -15,9 +15,10 @@ swap here swap ! ; immediate
 : again jmp, , ; immediate
 : recurse
 latestxt compile, ; immediate
-: ( begin getc dup 0= if refill then
-')' = if exit then again ; immediate
-: \ refill ; immediate
+: ( begin getc dup 0= if refill drop
+then ')' = if exit then again
+; immediate
+: \ source >in ! drop ; immediate
 : <> ( a b -- c ) = 0= ;
 : u> ( n -- b ) swap u< ;
 : 0<> ( x -- flag ) 0= 0= ;

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -15,9 +15,7 @@ swap here swap ! ; immediate
 : again jmp, , ; immediate
 : recurse
 latestxt compile, ; immediate
-: ( begin getc dup 0= if refill drop
-then ')' = if exit then again
-; immediate
+: ( begin getc ')' = until ; immediate
 : \ source >in ! drop ; immediate
 : <> ( a b -- c ) = 0= ;
 : u> ( n -- b ) swap u< ;

--- a/forth_src/sprite.fs
+++ b/forth_src/sprite.fs
@@ -40,4 +40,5 @@ over c! 1+ ;
 
 ( read sprite to address )
 : sp-data ( addr -- )
-#21 0 do refill rdb rdb rdb loop drop ;
+#21 0 do refill drop
+rdb rdb rdb loop drop ;

--- a/forth_src/testsee.fs
+++ b/forth_src/testsee.fs
@@ -4,7 +4,7 @@ include see
 
 : gives page see
 4 $d6 c@ do cr loop \ move to row 4
-refill source tuck
+refill drop source tuck
 type 0 do $400 i + c@ $4a0 i + c@
 <> abort" ko" loop ; immediate
 

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -545,50 +545,16 @@ EVALUATE
     sta TIB_PTR
     lda MSB + 1, x
     sta TIB_PTR + 1
-    jsr PLUS
     lda LSB, x
-    sta .bufend
+    sta TIB_SIZE
     lda MSB, x
-    sta .bufend + 1
+    sta TIB_SIZE + 1
+    inx
     inx
 
     ldy #0
     sty TO_IN_W
     sty TO_IN_W + 1
-
-    ; Determines TIB_SIZE.
-    lda TIB_PTR
-    sta W
-    lda TIB_PTR + 1
-    sta W + 1
-.findtibsizeloop
-    lda .bufend + 1
-    cmp W + 1
-    bcc .foundeol
-    bne +
-    lda W
-    cmp .bufend
-    bcs .foundeol
-+
-    ldy #0
-    lda (W),y
-    cmp #K_RETURN
-    beq .foundeol
-
-    inc W
-    bne +
-    inc W + 1
-+
-    jmp .findtibsizeloop
-
-.foundeol
-    lda W
-    sec
-    sbc TIB_PTR
-    sta TIB_SIZE
-    lda W + 1
-    sbc TIB_PTR + 1
-    sta TIB_SIZE + 1
 
     ldy #$ff
     sty SOURCE_ID_LSB

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -120,7 +120,7 @@ INIT_S = * + 1
     tax
 
 interpret_loop
-    jsr REFILL
+    jsr GETLINE
 
     jsr interpret_tib
     jmp interpret_loop
@@ -552,25 +552,6 @@ EVALUATE
     sta .bufend + 1
     inx
 
-    jsr evaluate_get_new_line
-    ldy #$ff
-    sty SOURCE_ID_LSB
-    sty SOURCE_ID_MSB
-
-.eval_loop
-    lda TIB_PTR + 1
-    cmp .bufend + 1
-    bcc +
-    lda TIB_PTR
-    cmp .bufend
-    bcc +
-    jmp RESTORE_INPUT ; exit
-+
-    jsr interpret_tib
-    jsr REFILL
-    jmp .eval_loop
-
-evaluate_get_new_line
     ldy #0
     sty TO_IN_W
     sty TO_IN_W + 1
@@ -608,21 +589,12 @@ evaluate_get_new_line
     lda W + 1
     sbc TIB_PTR + 1
     sta TIB_SIZE + 1
-    rts
 
-evaluate_consume_tib
-    lda TIB_PTR
-    clc
-    adc TIB_SIZE
-    sta TIB_PTR
-    lda TIB_PTR + 1
-    adc TIB_SIZE + 1
-    sta TIB_PTR + 1
-
-    inc TIB_PTR ; skip cr
-    bne +
-    inc TIB_PTR + 1
-+   rts
+    ldy #$ff
+    sty SOURCE_ID_LSB
+    sty SOURCE_ID_MSB
+    jsr interpret_tib
+    jmp RESTORE_INPUT
 
 .bufend
     !word 0

--- a/io.asm
+++ b/io.asm
@@ -77,12 +77,13 @@ TYPE ; ( caddr u -- )
     ldy #0
     jmp pushya
 
-    +BACKLINK "refill", 6
-REFILL
-
-READ_EOF = * + 1
-    lda #0
-    beq .not_eof
+GETLINE ; ( -- )
+    jsr REFILL
+    inx
+    lda MSB-1,x
+    beq +
+    rts
++   ; handle EOF
     stx W
     lda	SOURCE_ID_LSB
     jsr	CLOSE
@@ -94,12 +95,24 @@ READ_EOF = * + 1
 +   jsr CLRCHN
 ++  ldx W
     rts
+
+    +BACKLINK "refill", 6
+REFILL ; ( -- flag )
+
+READ_EOF = * + 1
+    lda #0
+    beq .not_eof
+.return_false
+    dex
+    lda #0
+    sta MSB,x
+    sta LSB,x
+    rts
+
 .not_eof
     lda SOURCE_ID_MSB
-    beq +
-    jsr evaluate_consume_tib
-    jmp evaluate_get_new_line
-+
+    bne .return_false ; evaluate = fail
+
     ldy #0
     sty TO_IN_W
     sty TO_IN_W + 1
@@ -127,6 +140,11 @@ READ_EOF = * + 1
     ; Set TIB_SIZE to number of chars fetched.
     stx TIB_SIZE
     ldx W
+.return_true
+    dex
+    lda #$ff
+    sta LSB,x
+    sta MSB,x
     rts
 
 .getLineFromDisk
@@ -142,16 +160,15 @@ READ_EOF = * + 1
     sta READ_EOF
     pla
     ora #0
-    beq -
+    beq .return_true
     cmp #K_RETURN
-    beq +
+    beq .return_true
     inc $d020
     ldy TIB_SIZE
     sta (W),y
     inc TIB_SIZE
     dec $d020
     jmp -
-+   rts
 
 GET_CHAR_FROM_TIB
     lda TO_IN_W
@@ -214,7 +231,7 @@ TO_IN_W
     +BACKLINK "getc", 4
     jsr GET_CHAR_FROM_TIB
     bne +
-    jsr REFILL
+    jsr GETLINE
     lda #K_RETURN
 +   ldy #0
     jmp pushya
@@ -226,7 +243,7 @@ CHAR ; ( name -- char )
     bne +
     inx
     inx
-    jsr REFILL
+    jsr GETLINE
     jmp -
 +   inx
     jmp FETCHBYTE

--- a/io.asm
+++ b/io.asm
@@ -77,6 +77,7 @@ TYPE ; ( caddr u -- )
     ldy #0
     jmp pushya
 
+    ; Calls REFILL. Closes active input source in case of error.
 GETLINE ; ( -- )
     jsr REFILL
     inx

--- a/io.asm
+++ b/io.asm
@@ -77,14 +77,12 @@ TYPE ; ( caddr u -- )
     ldy #0
     jmp pushya
 
-    ; Calls REFILL. Closes active input source in case of error.
 GETLINE ; ( -- )
     jsr REFILL
     inx
     lda MSB-1,x
-    beq +
-    rts
-+   ; handle EOF
+    bne .ret
+    ; REFILL failed. Close the active input source.
     stx W
     lda	SOURCE_ID_LSB
     jsr	CLOSE
@@ -95,6 +93,7 @@ GETLINE ; ( -- )
     jmp ++
 +   jsr CLRCHN
 ++  ldx W
+.ret
     rts
 
     +BACKLINK "refill", 6


### PR DESCRIPTION
Change REFILL to standard behavior.

Attempt to fill the input buffer from the input source, returning a true flag if successful.  Return false if EOF is reached. Return false when the input source is a string from EVALUATE.

Closes #244 