### PR TITLE
Minor edits of AsciiDoc manual

### DIFF
--- a/docs_src/anatomy.adoc
+++ b/docs_src/anatomy.adoc
@@ -14,7 +14,7 @@ To inspect the dictionary entry, type `latest dump`. You should see something li
 ----
 For this run, the name token of `bg` is placed at address $6228. The first byte, `02`, is the name length (`bg` has two characters). After that, the string `bg` follows. ($42 = `b`, $47 = `g`). The final two bytes contain the execution token of `bg`, starting at $39fd.
 
-The name length byte is also used to store special attributes of the word. Bit 7 is "immediate" flag, which means that the word should execute immediately instead of being compiled into word definitions. (`(` is such an example of an immediate word that does not get compiled.) Bit 6 is the "no-tail-call-elimination" flag, which makes sure that tail call elimination (the practice of replacing jsr/rts with jmp) is not performed if this word is the jsr target. Since `bg` does not have these flags set, bits 7 and 6 are both clear.
+The name length byte is also used to store special attributes of the word. Bit 7 is "immediate" flag, which means that the word should execute immediately instead of being compiled into word definitions. (``(`` is such an example of an immediate word that does not get compiled.) Bit 6 is the "no-tail-call-elimination" flag, which makes sure that tail call elimination (the practice of replacing jsr/rts with jmp) is not performed if this word is the jsr target. Since `bg` does not have these flags set, bits 7 and 6 are both clear.
 
 We saw that the `bg` execution token is $39fd. To inspect the code, type `$39fd dump` or `latest >xt dump`.
 

--- a/docs_src/config.adoc
+++ b/docs_src/config.adoc
@@ -15,13 +15,13 @@ v:: The text editor.
 
 To reduce RAM usage, you may make a stripped-down version of durexForth. Do this by following these steps:
 
-. Issue +---modules---+ to unload all modules, or +---editor---+ to unload the editor only.
-. One by one, load the modules you want included with your new Forth. (E.g. +include labels+)
-. Save the new system with e.g. +save-forth acmeforth+.
+. Issue `---modules---` to unload all modules, or `---editor---` to unload the editor only.
+. One by one, load the modules you want included with your new Forth. (E.g. `include labels`)
+. Save the new system with e.g. `save-forth acmeforth`.
 
 === Custom Start-Up
 
-You may launch a word automatically at start-up by setting the variable +start+ to the execution token of the word.  Example: +' megademo start !+ To save the new configuration to disk, type e.g. +save-forth megademo+.
+You may launch a word automatically at start-up by setting the variable `start` to the execution token of the word.  Example: `' megademo start !` To save the new configuration to disk, type e.g. `save-forth megademo`.
 
 When writing a new program using a PC text editor, it is practical to configure durexForth to compile and execute the program at startup. That can be set up using the following snippet:
 
@@ -35,13 +35,13 @@ save-forth @0:durexforth
 
 === Turn-key Operation
 
-Durexforth offers utilities to save your program in a turn-key fashion by including the +turnkey+ module once the program is ready to be saved.
+Durexforth offers utilities to save your program in a turn-key fashion by including the `turnkey` module once the program is ready to be saved.
 
-Programs can be saved in a compacted state using +save-pack+. These programs are stored with 32 bytes between +here+ and +latest+. When they are first loaded, they will restore the header space to its original +top+.
+Programs can be saved in a compacted state using `save-pack`. These programs are stored with 32 bytes between `here` and `latest`. When they are first loaded, they will restore the header space to its original `top`.
 
-If you have developed a program that has no further need of the interpreter, you can eliminate the dictionary headers entirely when saving with +save-prg+. This allows your program to use memory down to +here+ plus 32 bytes for safety.
+If you have developed a program that has no further need of the interpreter, you can eliminate the dictionary headers entirely when saving with `save-prg`. This allows your program to use memory down to `here` plus 32 bytes for safety.
 
-After either of these words have saved the file to disk, they will restore forth to the unpacked state, and strip the +turnkey+ module from the dictionary. This allows you to continue to use forth interactively in the case of +save-pack+. As +save-prg+ has stripped the dictionary headers from the system, it will no longer be usable. If you wish to test your program after saving, you can compile a call to +save-prg+ instead:
+After either of these words have saved the file to disk, they will restore forth to the unpacked state, and strip the `turnkey` module from the dictionary. This allows you to continue to use forth interactively in the case of `save-pack`. As `save-prg` has stripped the dictionary headers from the system, it will no longer be usable. If you wish to test your program after saving, you can compile a call to `save-prg` instead:
 ----
 : build save-prg mydemo start @ execute ;
 build

--- a/docs_src/editor.adoc
+++ b/docs_src/editor.adoc
@@ -2,7 +2,7 @@ The editor is a vi clone. Launch it by entering +v foo+ in the interpreter (+foo
 
 === Inserting Text
 
-At startup, the editor is in command mode. These commands start insert mode, which allows you to enter text. Return to command mode with ←.
+At startup, the editor is in command mode. These commands start insert mode, which allows you to enter text. Return to command mode with kbd:[←].
 
 i:: Insert text.
 R:: Replace text.
@@ -34,7 +34,7 @@ G:: Go to end of file.
 H:: Go to home window line.
 L:: Go to last window line.
 M:: Go to middle window line.
-/{string}:: Search forward for the next occurrence of the string.
+/__string__:: Search forward for the next occurrence of the string.
 *:: Search forward for the next occurrence of the word under the cursor.
 n:: Repeat the latest search.
 
@@ -46,7 +46,7 @@ ZZ:: Save and exit.
 :q:: Exit.
 :w:: Save. (Must be followed by return.)
 :w!filename:: Save as.
-F7:: Compile and run editor contents. On completion, enter +v+ to return to editor. To terminate a running program, press _RESTORE_.
+F7:: Compile and run editor contents. On completion, enter +v+ to return to editor. To terminate a running program, press kbd:[RESTORE].
 
 === Text Manipulation
 r:: Replace character under cursor.

--- a/docs_src/index.adoc
+++ b/docs_src/index.adoc
@@ -1,6 +1,9 @@
 = durexForth: Operators Manual
 Johan Kotlinski; Kevin Lee Reno; Poindexter Frink; Richard Halkyard
 :toc: preamble
+:doctype: book
+:experimental:
+// experimental enables the kbd: macro https://docs.asciidoctor.org/asciidoc/latest/macros/keyboard-macro/
 
 This manual is for durexForth, a modern Forth system for the Commodore 64.
 

--- a/docs_src/mnemonics.adoc
+++ b/docs_src/mnemonics.adoc
@@ -1,59 +1,63 @@
 // TODO can this list be put in (say 5) columns?
 
-[verse]
-adc,# adc, adc,x adc,y adc,(x) adc,(y)
-and,# and, and,x and,y and,(x) and,(y)
-asl,a asl, asl,x
-bcc,
-bcs,
-beq,
-bmi,
-bne,
-bpl,
-bvc,
-bvs,
-bit,
-brk,
-clc,
-cld,
-cli,
-clv,
-cmp,# cmp, cmp,x cmp,y cmp,(x) cmp,(y)
-cpx,# cpx,
-cpy,# cpy,
-dec, dec,x
-dex,
-dey,
-eor,# eor, eor,x eor,y eor,(x) eor,(y)
-inc, inc,x
-inx,
-iny,
-jmp, (jmp),
-jsr,
-lda,# lda, lda,x lda,y lda,(x) lda,(y)
-ldx,# ldx, ldx,y
-ldy ldy,# ldy, ldy,x
-lsr,a lsr, lsr,x
-nop,
-ora,# ora, ora,x ora,y ora,(x) ora,(y)
-pha,
-php,
-pla,
-plp,
-rol,a rol, rol,x
-ror,a ror, ror,x
-rti,
-rts,
-sbc,# sbc, sbc,x sbc,y sbc,(x) sbc,(y)
-sec,
-sed,
-sei,
-sta, sta,x sta,y sta,(x) sta,(y)
-stx, stx,y
-sty, sty,x
-tax,
-tay,
-tsx,
-txa,
-txs,
-tya,
+[cols="1,1,1,1,1,1"]
+[frame=none]
+[grid=none]
+|===
+
+|adc,# | adc, | adc,x | adc,y | adc,(x) | adc,(y)
+
+|and,# | and, | and,x | and,y | and,(x) | and,(y)
+
+|asl,a | asl, | asl,x |||
+
+|bcc, |bcs, |beq, |bmi,||
+|bne, |bpl, |bvc, |bvs,||
+
+|bit,
+|brk,
+||||
+
+|clc, |cld, |cli, |clv,||
+
+|cmp,# | cmp, | cmp,x | cmp,y | cmp,(x) | cmp,(y)
+
+|cpx,# | cpx, |cpy,# | cpy,||
+
+|dec, | dec,x |dex, |dey,||
+
+|eor,# | eor, | eor,x | eor,y | eor,(x) | eor,(y)
+
+|inc, | inc,x |inx, |iny,||
+
+|jmp, | (jmp), |jsr,|||
+
+|lda,# | lda, | lda,x | lda,y | lda,(x) | lda,(y)
+
+|ldx,# | ldx, || ldx,y||
+
+|ldy,# | ldy, | ldy,x|||
+
+|lsr,a | lsr, | lsr,x||
+
+|nop,
+
+|ora,# | ora, | ora,x | ora,y | ora,(x) | ora,(y)
+
+|pha, |php, |pla, |plp,||
+
+|rol,a | rol, | rol,x|||
+|ror,a | ror, | ror,x|||
+
+|rti, |rts,||||
+
+|sbc,# | sbc, | sbc,x | sbc,y | sbc,(x) | sbc,(y)
+
+|sec, |sed, |sei,|||
+
+|sta, || sta,x | sta,y | sta,(x) | sta,(y)
+
+|stx, | stx,y |sty, | sty,x||
+
+|tax, |tay, |tsx, |txa, |txs, |tya,
+|===

--- a/docs_src/sid.adoc
+++ b/docs_src/sid.adoc
@@ -1,10 +1,10 @@
 The `sid` module contains low-level words for controlling the SID chip. To load it, type `include sid`. To test that it works, run `sid-demo`.
 
 === Voice Control
-((voice! _( n -- )_ :: Select SID voice 0-2.
-((freq! _( n -- )_ :: Write 16-bit frequency.
-((pulse! _( n -- )_ :: Write 16-bit pulse value.
-((control! _( n -- )_ :: Write 8-bit control value.
+((voice!)) _( n -- )_ :: Select SID voice 0-2.
+((freq!)) _( n -- )_ :: Write 16-bit frequency.
+((pulse!)) _( n -- )_ :: Write 16-bit pulse value.
+((control!)) _( n -- )_ :: Write 8-bit control value.
 ((srad!)) _( srad -- )_ :: Write 16-bit ADSR value. (Bytes are swapped.)
 ((note!)) _( n -- )_ :: Play note in range [0, 94], where 0 equals C-0. The tuning is correct for PAL.
 

--- a/docs_src/tutorial.adoc
+++ b/docs_src/tutorial.adoc
@@ -4,12 +4,12 @@ Start up durexForth.
 The system will greet you with a blinking yellow cursor, waiting for your input.
 This is the interpreter, which allows you to enter Forth code interactively.
 
-Let us try the traditional first program: Type in `.( Hello, world! )` (and press Return).
+Let us try the traditional first program: Type in `.( Hello, world! )` (and press kbd:[Return]).
 The system will reply `Hello, world! ok`.
 The `ok` means that the system is healthy and ready to accept more input.
 
 Now, let us try some mathematics.
-`1 1 +` (followed by Return) will add 1 and 1, leaving 2 on the stack.
+`1 1 +` (followed by kbd:[Return]) will add 1 and 1, leaving 2 on the stack.
 This can be verified by entering `.s` to print the stack contents.
 Now enter `.` to pop the 2 and print it to screen, followed by another `.s` to verify that the stack is empty.
 
@@ -26,7 +26,7 @@ Then, try changing it back again with `0 bg!`.
 
 The v editor is convenient for editing larger pieces of code. With it, you keep an entire source file loaded in RAM, and you can recompile and test it easily.
 
-Start the editor by typing `v`. You will enter the red editor screen. To enter text, first press `i` to enter insert mode. This mode allows you to insert text into the buffer. You can see that it's active on the `I` that appears in the lower left corner. This is a good start for creating a program!
+Start the editor by typing `v`. You will enter the red editor screen. To enter text, first press kbd:[i] to enter insert mode. This mode allows you to insert text into the buffer. You can see that it's active on the `I` that appears in the lower left corner. This is a good start for creating a program!
 
 Now, enter the following lines...
 
@@ -35,9 +35,9 @@ Now, enter the following lines...
 ----
 
 ...and then press ← to leave insert mode.
-Press _F7_ to compile and run. If everything is entered right, you will see a beautiful color cycle.
+Press kbd:[F7] to compile and run. If everything is entered right, you will see a beautiful color cycle.
 
-When you finished watching, press _RESTORE_ to quit your program, then enter `v` to reopen the editor.
+When you finished watching, press kbd:[RESTORE] to quit your program, then enter `v` to reopen the editor.
 
 === Assembler
 

--- a/docs_src/words.adoc
+++ b/docs_src/words.adoc
@@ -185,7 +185,7 @@ if ... ((else)) ... then :: condition IF true-part ELSE false-part THEN rest
 : print0to7 8 0 do i . loop ;
 ----
 
-((do)) .. ((+loop)) :: Start a loop with a custom increment. Example:
+do .. ((+loop)) :: Start a loop with a custom increment. Example:
 
 ----
 ( prints odd numbers from 1 to n )
@@ -204,9 +204,9 @@ if ... ((else)) ... then :: condition IF true-part ELSE false-part THEN rest
 
 ((begin)) .. ((again)) :: Infinite loop.
 
-((begin)) .. ((until)) :: BEGIN loop-part condition UNTIL. Loop until condition is true.
+begin .. ((until)) :: BEGIN loop-part condition UNTIL. Loop until condition is true.
 
-((begin)) .. ((while)) .. ((repeat)) :: BEGIN condition WHILE loop-part REPEAT. Repeat loop-part while condition is true.
+begin .. ((while)) .. ((repeat)) :: BEGIN condition WHILE loop-part REPEAT. Repeat loop-part while condition is true.
 
 [[exit]] ((exit)) :: Exit function. Typical use: `: X test IF EXIT THEN ... ;`
 
@@ -306,7 +306,7 @@ Words for sending DOS commands to drives and reading drive status are available 
 backup
 ----
 
-((dos)) ( "cmd" -- )] Send _cmd_ to the current device's command channel, and print the response. Note that the remainder of the line is treated as part of the command. This makes it possible to refer to file names that contain spaces, but means that `dos` and its command should be on their own line, or the last words on a line. Example: `dos scratch0:old file` will delete a file named _old file_.
+((dos)) _( "cmd" -- )_ :: Send _cmd_ to the current device's command channel, and print the response. Note that the remainder of the line is treated as part of the command. This makes it possible to refer to file names that contain spaces, but means that `dos` and its command should be on their own line, or the last words on a line. Example: `dos scratch0:old file` will delete a file named _old file_.
 
 ==== Low-Level Device I/O
 


### PR DESCRIPTION
Mostly formatting tweaks. The assembly mnemonics page is probably debatable taste. The book doctype adds a title page, which might be desirable to adjust further (e.g. it supports background image). 