### PR TITLE
 Superfluous clrchn in SEND-CMD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Undefined behaviour after loading base.fs. broke in 1.5.1.
  - V: visual bug when saving.
  - V: only allow inserting control characters inside quotes.
+ - SEND-CMD: CLRCHN not required when current I/O channels are screen and keyboard.
 
 ## [4.0.0] - 2022-07-20
 ### Changed

--- a/forth/dos.fs
+++ b/forth/dos.fs
@@ -4,7 +4,7 @@ require io
 \ print response
 : send-cmd ( addr len -- )
 ?dup if $f $f open ioabort
-clrchn $f chkin ioabort
+$f chkin ioabort
 begin chrin emit readst until
 clrchn $f close cr
 else drop rderr then ;


### PR DESCRIPTION
 Default channels already set, Typing and seeing it in on screen. before calling ```send-cmd```