### PR TITLE
close_all_logical_files should do CLRCHN first in disk.asm

### DIFF
--- a/asm/disk.asm
+++ b/asm/disk.asm
@@ -275,6 +275,7 @@ INCLUDED
 
 ; Used registers: A, X, Y
 close_all_logical_files:
+    jsr CLRCHN
     ldx #0
 -   txa
     pha


### PR DESCRIPTION
 Like, so.