### PR TITLE
Changed S" .( ( , removed GETC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - S" max string length is reduced to 255 characters.
  - S" and .( no longer support multiple lines.
  - ( now only supports multiple lines when reading from text file.
- - MML string definitions are now done using the MML" word.
+ - Define MML strings using MML"
  - Changed REFILL to Forth standard behavior: Fill the input buffer from the input source, returning true if successful.
  - #> (the pictured numeric output string buffer) now uses its own buffer, separate from HERE.
  - Do not print "ok" while compiling. Makes it easier to re-enter multi-line word definitions in interpreter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - ERASE, PARSE, TRUE, FALSE
 ### Changed
  - S" max string length is reduced to 255 characters.
+ - Multi-line S" is no longer allowed.
+ - MML string definitions are now done using the MML" word.
  - Changed REFILL to Forth standard behavior: Fill the input buffer from the input source, returning true if successful.
  - #> (the pictured numeric output string buffer) now uses its own buffer, separate from HERE.
  - Do not print "ok" while compiling. Makes it easier to re-enter multi-line word definitions in interpreter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - ERASE, PARSE, TRUE, FALSE
 ### Changed
  - S" max string length is reduced to 255 characters.
- - Multi-line S" is no longer allowed.
+ - Disallow multi-line S" .(
  - MML string definitions are now done using the MML" word.
  - Changed REFILL to Forth standard behavior: Fill the input buffer from the input source, returning true if successful.
  - #> (the pictured numeric output string buffer) now uses its own buffer, separate from HERE.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - #> (the pictured numeric output string buffer) now uses its own buffer, separate from HERE.
  - Do not print "ok" while compiling. Makes it easier to re-enter multi-line word definitions in interpreter.
  - Moved tests to a separate disk (tests.d64).
+### Removed
+ - GETC
 ### Fixed
  - DOWORDS incorrectly quit for some non-false xt return values.
  - POSTPONE error handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - ERASE, PARSE, TRUE, FALSE
 ### Changed
  - S" max string length is reduced to 255 characters.
- - Disallow multi-line S" .(
+ - S" and .( no longer support multiple lines.
+ - ( now only supports multiple lines when reading from text file.
  - MML string definitions are now done using the MML" word.
  - Changed REFILL to Forth standard behavior: Fill the input buffer from the input source, returning true if successful.
  - #> (the pictured numeric output string buffer) now uses its own buffer, separate from HERE.

--- a/asm/core.asm
+++ b/asm/core.asm
@@ -1,5 +1,5 @@
 ; DROP SWAP DUP ?DUP NIP OVER 2DUP 1+ 1- + = 0= AND ! @ C! C@ COUNT < > MAX MIN
-; TUCK >R R> R@ BL PICK DEPTH WITHIN ERASE FILL BASE 2* ROT +!
+; TUCK >R R> R@ BL PICK DEPTH WITHIN ERASE FILL BASE 2* ROT +! 100/
 
     +BACKLINK "drop", 4 | F_IMMEDIATE
 DROP
@@ -410,4 +410,11 @@ BASE
     sta (W),y
     inx
     inx
+    rts
+
+    +BACKLINK "100/", 4 ; ( num addr -- )
+    lda MSB,x
+    sta LSB,x
+    lda #0
+    sta MSB,x
     rts

--- a/asm/io.asm
+++ b/asm/io.asm
@@ -1,4 +1,4 @@
-; EMIT PAGE RVS CR TYPE KEY? KEY REFILL SOURCE SOURCE-ID >IN GETC CHAR IOABORT
+; EMIT PAGE RVS CR TYPE KEY? KEY REFILL SOURCE SOURCE-ID >IN CHAR IOABORT
 
     +BACKLINK "emit", 4
 EMIT
@@ -201,14 +201,6 @@ TO_IN
     +VALUE TO_IN_W
 TO_IN_W
     !word 0
-
-    +BACKLINK "getc", 4
-    jsr GET_CHAR_FROM_TIB
-    bne +
-    jsr REFILL_OR_CLOSE
-    lda #K_RETURN
-+   ldy #0
-    jmp pushya
 
     +BACKLINK "char", 4
 CHAR ; ( name -- char )

--- a/forth/base.fs
+++ b/forth/base.fs
@@ -14,19 +14,24 @@ swap here swap ! ; immediate
 : again jmp, , ; immediate
 : recurse
 latestxt compile, ; immediate
-: ( begin getc ')' = until ; immediate
-: \ source >in ! drop ; immediate
-: <> ( a b -- c ) = 0= ;
-: u> ( n -- b ) swap u< ;
-: 0<> ( x -- flag ) 0= 0= ;
 
-: lits ( -- addr len )
-r> 1+ count 2dup + 1- >r ;
+: \ source >in ! drop ; immediate
+: <> = 0= ;
+: u> swap u< ;
+: 0<> 0= 0= ;
 
 : parse >r source >in @ /string
 over swap begin dup while over c@ r@ <>
 while 1 /string repeat then r> drop >r
 over - dup r> if 1+ then >in +! ;
+
+: ( source-id 1 < if ')' parse else
+begin >in @ ')' parse nip >in @ rot -
+= while refill drop repeat then ;
+immediate
+
+: lits ( -- addr len )
+r> 1+ count 2dup + 1- >r ;
 
 : s" ( -- addr len )
 postpone lits '"' parse dup c,

--- a/forth/base.fs
+++ b/forth/base.fs
@@ -29,10 +29,9 @@ while 1 /string repeat then r> drop >r
 over - dup r> if 1+ then >in +! ;
 
 : s" ( -- addr len )
-postpone lits here 0 c, 0
-begin getc dup '"' <>
-while c, 1+ repeat
-drop swap c! ; immediate
+postpone lits '"' parse dup c,
+begin ?dup while over c@ c,
+1 /string repeat drop ; immediate
 
 : ." postpone s" postpone type
 ; immediate

--- a/forth/base.fs
+++ b/forth/base.fs
@@ -33,10 +33,17 @@ immediate
 : lits ( -- addr len )
 r> 1+ count 2dup + 1- >r ;
 
+( "0 to foo" sets value foo to 0 )
+: (to) over 100/ over 2+ c! c! ;
+: to ' 1+ state c@ if
+postpone literal postpone (to) exit
+then (to) ; immediate
+
+: allot ( n -- ) here + to here ;
+
 : s" ( -- addr len )
-postpone lits '"' parse dup c,
-begin ?dup while over c@ c,
-1 /string repeat drop ; immediate
+postpone lits '"' parse dup c, tuck
+here swap move allot ; immediate
 
 : ." postpone s" postpone type
 ; immediate
@@ -66,10 +73,6 @@ parse-name asm included
 
 : -rot rot rot ;
 
-code 100/
-msb lda,x lsb sta,x
-0 lda,#   msb sta,x ;code
-
 ( creates value that is fast to read
   but can only be rewritten by "to".
    0 value foo
@@ -90,12 +93,6 @@ begin ?dup while space 1- repeat ;
 8b value w
 8d value w2
 9e value w3
-
-( "0 to foo" sets value foo to 0 )
-: (to) over 100/ over 2+ c! c! ;
-: to ' 1+ state c@ if
-postpone literal postpone (to) exit
-then (to) ; immediate
 
 : hex 10 base ! ;
 : decimal a base ! ;
@@ -128,8 +125,6 @@ code rshift ( x1 u -- x2 )
 lsb dec,x -branch bmi,
 msb 1+ lsr,x lsb 1+ ror,x
 latest >xt jmp,
-
-: allot ( n -- ) here + to here ;
 
 : variable
 0 value

--- a/forth/base.fs
+++ b/forth/base.fs
@@ -35,8 +35,7 @@ begin ?dup while over c@ c,
 
 : ." postpone s" postpone type
 ; immediate
-: .( begin getc dup ')' <>
-while emit repeat drop ; immediate
+: .( ')' parse type ; immediate
 .( compile base..)
 
 : case 0 ; immediate

--- a/forth/mml.fs
+++ b/forth/mml.fs
@@ -328,4 +328,13 @@ apply-sid
 \ restore sentinels
 r> r> c! r> r> c! r> r> c! ;
 
+:noname
+r> 1+ dup 2+ swap @ 2dup + 1- >r ;
+: mml" ( -- addr len )
+literal compile, here >r 0 ,
+begin >in @ '"' parse
+tuck here swap move dup allot
+dup r@ +! >in @ rot - = while
+refill drop repeat r> drop ; immediate
+
 base !

--- a/forth/mmldemo.fs
+++ b/forth/mmldemo.fs
@@ -4,10 +4,10 @@ require mml
 r> 1+ dup 2+ swap @ 2dup + 1- >r ;
 : mml" ( -- addr len )
 literal compile, here >r 0 ,
-begin source >in @ /string if 1 >in +!
-c@ dup '"' = if r> 2drop exit then
-c, 1 r@ +! else refill 2drop then again
-; immediate
+begin >in @ '"' parse
+tuck here swap move dup allot
+dup r@ +! >in @ rot - = while
+refill drop repeat r> drop ; immediate
 
 cr .( Frere Jaques)
 : frere-jaques

--- a/forth/mmldemo.fs
+++ b/forth/mmldemo.fs
@@ -1,26 +1,27 @@
 require mml
+
+:noname
+r> 1+ dup 2+ swap @ 2dup + 1- >r ;
+: mml" ( -- addr len )
+literal compile, here >r 0 ,
+begin source >in @ /string if 1 >in +!
+c@ dup '"' = if r> 2drop exit then
+c, 1 r@ +! else refill 2drop then again
+; immediate
+
 cr .( Frere Jaques)
 : frere-jaques
-s" o3l4fgaffgafab->c&c<ab->c&cl8cdc<b-
+mml" o3l4fgaffgafab->c&c<ab->c&cl8cdc<b-
 l4af>l8cdc<b-l4affcf&ffcf&f"
-s" r1r1o3l4fgaffgafab->c&c<ab->c&cl8cd
+mml" r1r1o3l4fgaffgafab->c&c<ab->c&cl8cd
 c<b-l4af>l8cdc<b-l4affcf&ffcf&f"
-s" " play-mml ;
+mml" " play-mml ;
 frere-jaques
-
-\ l" is like s", but supports strings
-\ longer than 255 bytes.
-: litl ( -- addr len )
-r> 1+ dup 2+ swap @ 2dup + 1- >r ;
-: l" ( -- addr len )
-postpone litl here 0 , 0
-begin getc dup '"' <>
-while c, 1+ repeat
-drop swap ! ; immediate
 
 cr .( Sarias Song)
 : sarias-song
-l" l16o3f8o4crcrcro3f8o4crcrcro3f8o4crc
+mml"
+l16o3f8o4crcrcro3f8o4crcrcro3f8o4crc
 rcro3f8o4crcro3cre8o4crcrcro3e8o4
 crcrcro3e8o4crcrcro3e8o4crcro3c8f8o4crc
 rcro3f8o4crcrcro3f8o4crcrcro3f8o4
@@ -33,13 +34,15 @@ o3gro2gro3grcro4cro3cro4cro2aro3ar
 o2aro3aro3drararrrdrararrrcrbrbrrrcrbrb
 rrrerarrrarerarrrarerg+rg+rg+rg+r
 rre&er"
-s" l16o5frarb4frarb4frarbr>erd4<b8>cr<b
+mml"
+l16o5frarb4frarb4frarbr>erd4<b8>cr<b
 rgre2&e8drergre2&e4frarb4frarb4fr
 arbr>erd4<b8>crer<brg2&g8brgrdre2&e4r1
 r1frgra4br>crd4e8frg2&g4r1r1<f8er
 a8grb8ar>c8<br>d8cre8drf8er<b>cr<ab1&b2
 r4e&er"
-s" l16r1r1r1r1r1r1r1r1o4drerf4grarb4>c8
+mml"
+l16r1r1r1r1r1r1r1r1o4drerf4grarb4>c8
 <bre2&e4drerf4grarb4>c8dre2&e4<dr
 erf4grarb4>c8<bre2&e4d8crf8erg8fra8grb8
 ar>c8<br>d8crefrde1&e2r4"

--- a/forth/mmldemo.fs
+++ b/forth/mmldemo.fs
@@ -1,14 +1,5 @@
 require mml
 
-:noname
-r> 1+ dup 2+ swap @ 2dup + 1- >r ;
-: mml" ( -- addr len )
-literal compile, here >r 0 ,
-begin >in @ '"' parse
-tuck here swap move dup allot
-dup r@ +! >in @ rot - = while
-refill drop repeat r> drop ; immediate
-
 cr .( Frere Jaques)
 : frere-jaques
 mml" o3l4fgaffgafab->c&c<ab->c&cl8cdc<b-

--- a/manual/mml.adoc
+++ b/manual/mml.adoc
@@ -2,13 +2,13 @@
 
 Music Macro Language (MML) has been used since the 1970s to sequence music on computer and video game systems. The MML package is loaded with `include mml`. Two demonstration songs can be found in the `mmldemo` package.
 
-MML songs are played using the Forth word ((play-mml)) which takes three strings, one MML melody for each of the three SID voices. An example song is as follows:
+MML songs are played using the Forth word ((play-mml)) which takes three MML strings, one MML melody for each of the three SID voices. An example song is as follows:
 
 ----
 : frere-jaques
-s" o3l4fgaffgafab->c&c<ab->c&cl8cdc<b-l4af>l8cdc<b-l4affcf&ffcf&f"
-s" r1o3l4fgaffgafab->c&c<ab->c&cl8cdc<b-l4af>l8cdc<b-l4affcf&ffcf&f"
-s" " play-mml ;
+mml" o3l4fgaffgafab->c&c<ab->c&cl8cdc<b-l4af>l8cdc<b-l4affcf&ffcf&f"
+mml" r1o3l4fgaffgafab->c&c<ab->c&cl8cdc<b-l4af>l8cdc<b-l4affcf&ffcf&f"
+mml" " play-mml ;
 ----
 
 ==== Commands

--- a/manual/words.adoc
+++ b/manual/words.adoc
@@ -228,7 +228,6 @@ case
 
 ((key)) _( -- c )_ :: Get one character from the keyboard.
 ((key?)) _( -- flag )_ :: Return true if a character is available for `key`.
-((getc)) _( -- c )_ :: Consume the next character from the input buffer and increases `>in` by one. If no characters are available, the input buffer is refilled as needed.
 ((char)) _( -- c )_ :: Parse the next word, delimited by a space, and puts its first character on the stack.
 ((>in)) _( -- addr )_ :: Give the address of a cell containing the offset in characters from the start of the input buffer to the start of the parse area.
 ((refill)) _( -- flag )_ :: Attempt to fill the input buffer from the input source, returning true if successful.


### PR DESCRIPTION
S" .( ( now handles multiple lines according to standard.

GETC is removed.

MML strings are now defined using MML"

Closes #539 