### PR TITLE
optimize `CHAR_TO_LOWERCASE`

### DIFF
--- a/asm/lowercase.asm
+++ b/asm/lowercase.asm
@@ -1,8 +1,8 @@
 CHAR_TO_LOWERCASE ; ( a -- a )
-    cmp #'Z' + 1
-    bcs +
     cmp #'A'
     bcc +
+    cmp #'Z' + 1
+    bcs +
     sec
-    sbc #'A' - #'a'
+    sbc #'A' - 'a'
 +   rts

--- a/asm/lowercase.asm
+++ b/asm/lowercase.asm
@@ -1,20 +1,8 @@
 CHAR_TO_LOWERCASE ; ( a -- a )
-    sta .save
-    sec
-    sbc #'a' + $80
-    cmp #1 + 'z' - 'a'
+    cmp #'Z' + 1
     bcs +
-    adc #'a'
-    rts
-+
-.save = * + 1
-    lda #0
+    cmp #'A'
+    bcc +
     sec
-    sbc #'A'
-    cmp #1 + 'z' - 'a'
-    bcs +
-    adc #'a'
-    rts
-+
-    lda .save
-    rts
+    sbc #'A' - #'a'
++   rts


### PR DESCRIPTION
Does only a single cmp instruction in the common case of characters less than 'A'.