### PR TITLE
Fix tick

### DIFF
--- a/asm/interpreter.asm
+++ b/asm/interpreter.asm
@@ -255,7 +255,7 @@ print_word_not_found_error ; ( caddr u -- )
     lda MSB-1,x
     beq print_word_not_found_error
     inx
-    sta MSB,X
+    sta MSB,x
     lda LSB-2,x
     sta LSB,x
     jmp TO_XT

--- a/asm/interpreter.asm
+++ b/asm/interpreter.asm
@@ -250,12 +250,15 @@ print_word_not_found_error ; ( caddr u -- )
     +BACKLINK "'", 1
     jsr PARSE_NAME
     jsr TWODUP
-    jsr FIND_NAME
-    lda MSB,x
+    jsr FIND_NAME ; ( addr u nt|0 )
+    inx
+    lda MSB-1,x
     beq print_word_not_found_error
-+   jsr TO_XT
-    jsr NIP
-    jmp NIP
+    inx
+    sta MSB,X
+    lda LSB-2,x
+    sta LSB,x
+    jmp TO_XT
 
     +BACKLINK "find", 4
 FIND ; ( xt -1 | xt 1 | caddr 0 )


### PR DESCRIPTION
[This commit](https://github.com/jkotlinski/durexforth/commit/9c906de02985912c115f16b57d041035a9f82dd8) broke error reporting when `'` was used with a missing word. This PR fixes that. The 0 from `find-name` remained on the stack where `notfound` interprets it as the string length.