### PR TITLE
 IEC documentation edit

### DIFF
--- a/forth/iec.fs
+++ b/forth/iec.fs
@@ -1,4 +1,3 @@
-require io
 
 code listen ( dv -- )
 here 1+
@@ -66,6 +65,8 @@ dex, w stx, 0 lda,# msb sta,x
 $ffa5 jsr, \ acptr
 w ldx, lsb sta,x
 rts, end-code
+
+require io
 
 : iqt readst ioabort ; \ legacy of if quit then
 

--- a/manual/words.adoc
+++ b/manual/words.adoc
@@ -347,11 +347,11 @@ These words allow access to serial devices without accessing the file system, an
 ((listen)) _( dv -- ioresult )_ :: Send IEC listen to dv.
 ((second)) _( command+sa -- ioresult )_ :: Send IEC command and secondary address after listen.
 ((unlisten)) _( -- )_ :: Send IEC unlisten to all channels.
-((ciout)) _( -- u )_ ::  Puts a data byte onto the serial bus using full handshaking.
+((ciout)) _( u -- )_ ::  Puts a data byte onto the serial bus using full handshaking.
 ((talk)) _( dv -- ioresult )_ :: Send IEC talk to dv.
 ((tksa)) _( command+sa -- ioresult )_ :: Send IEC command and secondary address after talk.
 ((untalk)) _( -- )_ :: Send IEC untalk to all channels.
-((acptr)) _( u -- )_ :: Get a byte of data from the serial bus using full handshaking.
+((acptr)) _( -- u )_ :: Get a byte of data from the serial bus using full handshaking.
 
 
 ====


### PR DESCRIPTION
 Fixed typo of stack diagramming of IEC words.  Also considering IEC words to use current device rather than stack input.