### PR TITLE
Mega65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - DEFINE assigns HERE to a word in the word list and begins compilation.
  - DEFCODE does the same as DEFINE, but begins a CODE: segment instead.
  - V commands: A, R, +, -, HOME, e, C, D, s, S, H, L, M, ^w, f, F
+ - Native support for Commodore 128
+ - Split V and GFX code into common and platform-specific components
+ - PLATFORM identifies whether durexForth is running on a Commodore 64 or 128
 ### Fixed
  - SP-X! had bug in most significant bit
  - GFX: PEEK fetched bitmap pixels from ROM instead of RAM

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,14 @@ SRC_DIR = forth_src
 SRCS_COMMON = $(wildcard $(SRC_DIR)/*.fs)
 SRCS_C64 = $(wildcard $(SRC_DIR)/c64/*.fs)
 SRCS_C128 = $(wildcard $(SRC_DIR)/c128/*.fs)
+SRCS_M65 = $(wildcard $(SRC_DIR)/m65/*.fs)
 
 PETSRCS_COMMON = $(subst forth_src/,build/,$(SRCS_COMMON:%.fs=%.pet))
 PETSRCS_C64 = $(subst forth_src/,build/,$(SRCS_C64:%.fs=%.pet))
 PETSRCS_C128 = $(subst forth_src/,build/,$(SRCS_C128:%.fs=%.pet))
+PETSRCS_M65 = $(subst forth_src/,build/,$(SRCS_M65:%.fs=%.pet))
 
-PETSRCS_ALL = $(PETSRCS_COMMON) $(PETSRCS_C64) $(PETSRCS_C128)
+PETSRCS_ALL = $(PETSRCS_COMMON) $(PETSRCS_C64) $(PETSRCS_C128) $(PETSRCS_M65)
 
 SRCNAME = $(patsubst %.pet,%,$(notdir $(1)))
 
@@ -24,12 +26,12 @@ SEPARATOR_NAME1 = '=-=-=-=-=-=-=-=,s'
 SEPARATOR_NAME2 = '=-------------=,s'
 SEPARATOR_NAME3 = '=-=---=-=---=-=,s'
 
-all: durexforth.d64 durexforth128.d64
+all: durexforth.d64 durexforth128.d64 durexforthm65.d64
 
 docs:
 	$(MAKE) -C docs
 
-deploy: deploy/durexforth-$(TAG_DEPLOY).pdf deploy/durexforth-$(TAG_DEPLOY).d64 deploy/durexforth-$(TAG_DEPLOY).crt deploy/durexforth128-$(TAG_DEPLOY).d64
+deploy: deploy/durexforth-$(TAG_DEPLOY).pdf deploy/durexforth-$(TAG_DEPLOY).d64 deploy/durexforth-$(TAG_DEPLOY).crt deploy/durexforth128-$(TAG_DEPLOY).d64 deploy/durexforthm65-$(TAG_DEPLOY).d64
 
 .PHONY: all clean docs deploy
 
@@ -47,6 +49,11 @@ deploy/durexforth128-$(TAG_DEPLOY).d64: durexforth128.d64
 	@mkdir -p deploy
 	cp $< $@
 	x128 -warp +confirmonexit $@
+
+deploy/durexforthm65-$(TAG_DEPLOY).d64: durexforthm65.d64
+	@mkdir -p deploy
+	cp $< $@
+	xmega65 $@
 
 # Build a cartridge image out of the precompiled Forth
 deploy/durexforth-$(TAG_DEPLOY).crt: deploy/durexforth-$(TAG_DEPLOY).d64 cart.asm
@@ -72,11 +79,23 @@ durexforth128.d64: durexforth128.prg $(EMPTY_FILE) $(PETSRCS_COMMON) $(PETSRCS_C
 	$(foreach f,$(PETSRCS_COMMON) $(PETSRCS_C128),-write $f $(call SRCNAME,$f)) \
 	-attach $@ -write $(EMPTY_FILE) $(SEPARATOR_NAME3)
 
+durexforthm65.d64: durexforthm65.prg $(EMPTY_FILE) $(PETSRCS_COMMON) $(PETSRCS_M65)
+	$(C1541) -format "durexforth,DF"  d64 $@ \
+	-attach $@ -write durexforthm65.prg durexforth \
+	-attach $@ -write $(EMPTY_FILE) $(SEPARATOR_NAME1) \
+	-attach $@ -write $(EMPTY_FILE) $(TAG_DEPLOY_DOT),s \
+	-attach $@ -write $(EMPTY_FILE) $(SEPARATOR_NAME2) \
+	$(foreach f,$(PETSRCS_COMMON) $(PETSRCS_M65),-write $f $(call SRCNAME,$f)) \
+	-attach $@ -write $(EMPTY_FILE) $(SEPARATOR_NAME3)
+
 durexforth.prg: *.asm
 	$(AS) -f cbm -DTARGET=64 -o $@ --vicelabels durexforth.lbl --report durexforth.lst durexforth.asm
 
 durexforth128.prg: *.asm
 	$(AS) -f cbm -DTARGET=128 -o $@ --vicelabels durexforth.lbl --report durexforth.lst durexforth.asm
+
+durexforthm65.prg: *.asm
+	$(AS) -f cbm -DTARGET=65 -o $@ --vicelabels durexforth.lbl --report durexforth.lst durexforth.asm
 
 $(PETSRCS_ALL) : build/%.pet : $(SRC_DIR)/%.fs | build/header ext/petcom
 	@mkdir -p $(dir $@)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ all:	durexforth.pdf
 
 SECTIONS = release_license.tex \
         intro.tex tutorial.tex editor.tex words.tex gfx.tex sid.tex mml.tex \
-        asm.tex mnemonics.tex memmap.tex anatomy.tex
+        asm.tex c128.tex mnemonics.tex memmap.tex anatomy.tex
 GENERATED = params-g.tex
 
 durexforth.pdf:	manual.tex $(SECTIONS)

--- a/docs/c128.tex
+++ b/docs/c128.tex
@@ -1,0 +1,103 @@
+\chapter{Commodore 128}
+
+\section{Introduction}
+
+If you are the lucky owner of a Commodore 128, durexForth can run in native 128 mode, with full support for the 128's 80 column text display, 2MHz processor mode, and fast-serial data transfer (with fast-serial-capable disk drives).
+
+\section{Features}
+
+\subsection{80 Column Display}
+
+The Commodore 128 has two independent displays - the 40-column, Commodore-64-compatible VIC-IIe, and the 80-column VDC. durexForth supports text output both displays, and will default to the display that was in use at the time durexForth was started.
+
+As in Commodore BASIC, it is possible to switch between displays on-the-fly by pressing the ESC key, followed by the X key.
+
+\subsection{Graphics}
+
+The 80-column display is only supported for text output. durexForth's graphics words will always draw to the 40-column display, regardless of which display is selected for text. If you have separate monitors connected to your Commodore 128, you can use this to your advantage, interacting with the interpreter on the 80 column display while graphics are displayed on the 40 column display.
+
+\subsection{Fast Mode}
+
+The Commodore 128's `Fast' mode doubles the system clock speed, running at 2MHz rather than 1MHz. Due to a limitation in the VIC-IIe chip, the 40-column display can only operate at 1MHz, and durexForth blanks the 40-column display while the system is in fast mode. As a result, the system should not be put into fast mode while graphics are being displayed, or the 40-column display is selected for text.
+
+\subsection{Memory}
+
+The Commodore 128 has 128KB of RAM, divided into two 64KB banks, RAM 0 and RAM 1. The durexForth interpreter and dictionary reside entirely in RAM 0, leaving RAM 1 free for use by user programs.
+
+The \texttt{!far}, \texttt{@far}, \texttt{c!far} and \texttt{c@far} words can be used to read and write `far' memory, taking a bank number in addition to the address used by their non-far counterparts.
+
+\texttt{sysfar} works in a similar fashion, allowing subroutines in far memory to be called from Forth.
+
+\section{Compatibility}
+
+While every effort has been made to make durexForth's included word-set compatible with the Commodore 128, existing Forth code may need to be modified in order to run successfully on the Commodore 128. In general, code that exclusively calls durexForth words and does not access Kernal variables or call Kernal routines, will run unchanged on the Commodore 128. Code that does any of the following, will require changes:
+
+\begin{itemize}
+\item Reads or writes to Kernal variables.
+
+Many Kernal variables have different locations on the Commodore 128.
+
+\item Calls to Kernal or BASIC routines using \texttt{sys} or Assembler code.
+
+While routines in the `public' Kernal jump table (\texttt{\$ff83}-\texttt{\$fff3}) are generally compatible, jumping directly into ROM routines will likely not work.
+
+\item Writes to VIC registers \texttt{\$d011}, \texttt{\$d016}, or \texttt{\$d018}.
+
+These registers are under control of the Commodore 128's IRQ handler, and any data written to them will be overwritten on the next vertical refresh.
+
+\item Writes to \texttt{\$01}
+
+Memory banking on the Commodore 128 works entirely differently to the Commodore 64, and \texttt{\$01} serves different functions.
+
+\item Writing to addresses \texttt{\$ff00}-\texttt{\$ff04}
+
+Addresses \texttt{\$ff00}-\texttt{\$ff04} are hard-wired to registers in the Commodore 128's Memory Management Unit. Attempting to write to memory at these addresses will modify the computer's memory map and cause a crash.
+
+\end{itemize}
+
+It is beyond the scope of this manual to explain the exact changes required to resolve all of these differences. For further details, the following books are indispensible:
+
+\begin{itemize}
+\item The \href{https://archive.org/details/C128_Programmers_Reference_Guide_1986_Bamtam_Books}{Commodore 128 Programmer’s Reference Guide} by Commodore Business Machines Inc.
+
+\item \href{https://archive.org/details/Compute_s_Mapping_the_Commodore_128/}{Mapping the Commodore 128} by Ottis R. Cowper.
+\end{itemize}
+
+The \texttt{gfxcore} and \texttt{vcore} source files contain the platform-specific components of the \texttt{gfx} library and the \texttt{v} text editor, and may be useful as examples of the kinds of changes required.
+
+\section{Additional Words}
+
+In addition to the words described so far, durexForth provides some additional words for accessing the Commodore 128's extended capabilities:
+
+\subsection{Speed Control}
+
+\begin{description}
+    \item[fast ( -- )] Sets the Commodore 128's clock speed to 2Mhz for faster processing.
+    \item[slow ( -- )] Sets the Commodore 128's clock speed to 1Mhz for greater compatibility.
+    \item[fast? ( -- is-fast )] Returns 1 if the Commodore 128's clock speed is 2Mhz, and 0 if the clock speed is 1Mhz.
+\end{description}
+
+Keep in mind that, due to hardware limitations, the 40-column screen will be blanked while the system is in \texttt{fast} mode.
+
+\subsection{Far Memory}
+
+These words, for manipulating memory across banks, are available by including \texttt{far}.
+
+\begin{description}
+    \item[sysfar ( bank addr -- )] Call a subroutine in the given memory bank. The helper variables \texttt{ar}, \texttt{xr}, \texttt{yr} and \texttt{sr} can be used to set arguments and get results through the a, x, y and status registers.
+    \item[!far ( value bank addr -- )] Store a 16-bit value to an address in the given memory bank.
+    \item[@far ( bank addr -- value )] Retrieve a 16-bit value from an address in the given memory bank.
+    \item[c@far ( bank addr -- value )] Store an 8-bit value to an address in the given memory bank.
+    \item[c!far ( value bank addr -- )] Retrieve an 8-bit value from an address in the given memory bank.
+\end{description}
+
+The \texttt{bank} argument is a memory configuration identifier from 0 to 15. In general, the following configurations are useful:
+
+\begin{description}
+    \item[0] RAM bank 0, no IO or ROM
+    \item[1] RAM bank 1, no IO or ROM
+    \item[14] RAM bank 0 + BASIC ROM + Character ROM + Kernal
+    \item[15] RAM bank 0 + BASIC ROM + IO + Kernal
+\end{description}
+
+For a full list of memory configurations and further explanation, see the \href{https://archive.org/details/C128_Programmers_Reference_Guide_1986_Bamtam_Books}{Commodore 128 Programmer’s Reference Guide}.

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -32,6 +32,7 @@
 \input{sid.tex}
 \input{mml.tex}
 \input{asm.tex}
+\input{c128.tex}
 \appendix
 \input{mnemonics.tex}
 \input{memmap.tex}

--- a/docs/memmap.tex
+++ b/docs/memmap.tex
@@ -1,5 +1,6 @@
 \chapter{Memory Map}
 
+\section{Commodore 64}
 \begin{description}
 \item[3 - \$3a] Parameter stack, LSB section.
 \item[\$3b - \$72] Parameter stack, MSB section.
@@ -20,6 +21,29 @@
 \item[\$cc00 - \$cfff] Hi-res graphics colors.
 \item[\$d000 - \$dfff] I/O area. 
 \item[\$e000 - \$ffff] Kernal / hi-res graphics bitmap.
+\end{description}
+
+\section{Commodore 128}
+\begin{description}
+\item[3 - \$3a] Parameter stack, LSB section.
+\item[\$3b - \$72] Parameter stack, MSB section.
+\item[\$8b - \$8c] w (work area for code words).
+\item[\$8d - \$8e] w2 (work area for code words).
+\item[\$9e - \$9f] w3 (work area for code words).
+\item[\ldots]
+\item[\$100 - \$1ff] Return stack.
+\item[\$200 - \$258] Text input buffer.
+\item[\$B00 - \$BFF] PAD Scratch pad memory, Cassette Buffer, untouched by DurexForth. 
+\item[\ldots]
+\item[\$1c01 - \texttt{here}] Forth Kernel followed by code and data space.
+\item[\ldots]
+\item[\$7000 - \texttt{eof}] Editor text buffer. Grows upwards as needed.
+\item[\ldots]
+\item[\texttt{latest} - \$9fff] Dictionary. Grows downwards as needed.
+\item[\$a000 - \$bfff] Free RAM.
+\item[\$c000 - \$cfff] Kernal / Hi-res graphics bitmap.
+\item[\$d000 - \$dfff] I/O area / Hi-res graphics bitmap.
+\item[\$e000 - \$ffff] Kernal / hi-res graphics colors.
 
 \end{description}
 

--- a/docs/words.tex
+++ b/docs/words.tex
@@ -450,3 +450,14 @@ $cbff top!
 \end{description}
 
 	Further details on use of these words outlined in the Turn-key Operation section of the tutorial.
+
+\section{Platform Detection}
+
+\texttt{include platform} will detect the type of system durexForth is currently running on, and create the constant \texttt{platform} with a corresponding value.
+
+Currently-supported \texttt{platform} values are:
+
+\begin{description}
+\item[64] Commodore 64, SX-64, or Commodore 128 running in Commodore 64 mode.
+\item[128] Commodore 128 running in native mode.
+\end{description}

--- a/durexforth.asm
+++ b/durexforth.asm
@@ -28,9 +28,16 @@
 !set TARGET = 64
 }
 
+
 !if TARGET = 128 {
 BASIC_START = $1c01
-} else {
+}
+
+!if TARGET = 65 {
+BASIC_START = $2001
+} 
+
+!if TARGET = 64 {
 BASIC_START = $0801
 }
 
@@ -140,7 +147,14 @@ entry
 !if TARGET = 128 {
     lda #14
     jsr PUTCHR
-} else {
+}
+
+!if TARGET = 65 {
+    lda #14
+    jsr PUTCHR
+}
+
+!if TARGET = 64 {
     lda	#%00010110 ; lowercase
     sta	VIC_ADDR
 }

--- a/durexforth.asm
+++ b/durexforth.asm
@@ -114,7 +114,18 @@ INIT_STATUS = $0a04
 CASSETTEBUF = $0b00
 KEYIN = $c006
 MMUCR = $ff00
-} else {
+} 
+
+!if TARGET = 65 {
+    NDX = $c6
+    QTSW = $d4
+    COLOR = $286
+    CASSETTEBUF = $033c
+
+    KEYIN = $ffe4
+}
+
+!if TARGET = 64 {
 NDX = $c6
 QTSW = $d4
 COLOR = $286

--- a/forth_src/base.fs
+++ b/forth_src/base.fs
@@ -85,7 +85,6 @@ msb lda,x lsb sta,x
 dup code lda,# 100/ ldy,#
 ['] pushya jmp, ;
 : constant value ;
-$33c constant pad
 : space bl emit ;
 : spaces ( n -- )
 begin ?dup while space 1- repeat ;
@@ -108,7 +107,7 @@ postpone drop postpone drop ; immediate
 
 
 : save-forth ( strptr strlen -- )
-801 $a000 d word count saveb ;
+basic-start $a000 d word count saveb ;
 
 code 2/
 msb lda,x 80 cmp,# msb ror,x lsb ror,x
@@ -214,6 +213,7 @@ marker ---modules---
 .( labels..) include labels
 .( doloop..) include doloop
 .( sys..) include sys
+.( kernal..) include kernal
 .( debug..) include debug
 .( ls..) include ls
 .( require..) include require
@@ -224,7 +224,7 @@ include turnkey
 cr
 .( cart: )
 $4000 $68 -
-here $801 - top latest -
+here basic-start - top latest -
 $21 + + -
 . .( bytes remain.) cr
 

--- a/forth_src/c128/c128.fs
+++ b/forth_src/c128/c128.fs
@@ -1,0 +1,27 @@
+\ Useful words for the Commodore 128
+
+\ Put C128 into 2MHz mode
+\ disables 40 column display
+code fast ( - )
+$d011 lda,
+%11101111 and,#
+$d011 sta,
+$d030 lda,
+%00000001 ora,#
+$d030 sta,
+;code
+
+\ Put C128 into 1MHz mode
+\ re-enables 40 column display
+code fast ( - )
+$d011 lda,
+%00010000 ora,#
+$d011 sta,
+$d030 lda,
+%11111110 and,#
+$d030 sta,
+;code
+
+: fast? ( - is-fast ) \ get current processor speed
+$d030 c@
+%00000001 and,# ;

--- a/forth_src/c128/far.fs
+++ b/forth_src/c128/far.fs
@@ -1,0 +1,74 @@
+( routines for accessing memory across
+banks on the commodore 128 )
+
+code c!far ( value bank addr -- )
+\ store addr in w
+lsb lda,x w sta,
+msb lda,x w 1+ sta, inx,
+w lda,# $02b9 sta, \ stavec = w
+lsb lda,x w2 1+ sta, inx, \ w2h = bank
+lsb lda,x inx, \ a = value
+w2 stx, \ w2l = x
+w2 1+ ldx, \ x = bank
+0 ldy,# \ y = offset = 0
+$ff77 jsr, \ indsta
+w2 ldx, \ restore x
+;code
+
+code c@far ( bank addr -- value )
+\ store addr in w
+lsb lda,x w sta,
+msb lda,x w 1+ sta, inx,
+w2 stx, \ w2l = x
+lsb lda,x tax, \ x = bank
+0 ldy,# \ y = offset = 0
+w lda,# \ a = ptr to w
+$ff74 jsr, \ indfet
+w2 ldx, \ restore x
+lsb sta,x 0 lda,# msb sta,x 
+;code
+
+code !far ( value bank addr -- )
+\ store addr in w
+lsb lda,x w sta,
+msb lda,x w 1+ sta, inx,
+w lda,# $02b9 sta, \ stavec = w
+lsb lda,x w2 1+ sta, inx, \ w2h = bank
+
+\ low byte
+lsb lda,x \ a = value
+w2 stx, \ w2l = x
+w2 1+ ldx, \ x = bank
+0 ldy,# \ offset = 0
+$ff77 jsr, \ INDSTA
+
+\ high byte
+w2 ldx, \ restore x
+msb lda,x inx, \ a = value
+w2 stx, \ w2l = x
+w2 1+ ldx, \ x = bank
+1 ldy,# \ offset = 1
+$ff77 jsr, \ indsta
+w2 1+ ldx, \ restore x
+;code
+
+code @far ( bank addr -- value )
+\ store addr in w
+lsb lda,x w sta,
+msb lda,x w 1+ sta, inx,
+w2 stx, \ w2l = x
+lsb lda,x tax, \ x = bank
+w2 1+ stx, \ w2h = x
+w lda,# \ a = ptr to w
+
+\ low byte
+0 ldy,# \ offset = 0
+$ff74 jsr, \ INDFET
+w2 ldx, lsb sta,x
+
+w2 1+ ldx, \ x = bank
+1 ldy,# \ offset = 1
+w lda,# \ a = ptr to w
+$ff74 jsr, \ INDFET
+w2 ldx, msb sta,x
+;code

--- a/forth_src/c128/gfxcore.fs
+++ b/forth_src/c128/gfxcore.fs
@@ -1,0 +1,43 @@
+(
+The C128's MMU has 'magic' addresses 
+at $ff00-$ff04 that our bitmap must not
+interfere with; so the bitmap must start
+at $c000, with the color map at $e000.
+Note that this means part of the bitmap
+is under IO space, so clrcol and blkcol
+can no longer 'blindly' write to it.
+)
+
+$c000 value bmpbase
+$e000 value colbase
+
+code kernal-in
+%00001110 lda,# $ff00 sta, cli, ;code
+code kernal-out
+sei, %00111111 lda,# $ff00 sta, ;code
+code charrom-in
+$ff00 lda, %11001111 and,#
+%00000001 ora,# $ff00 sta, ;code
+
+code hires
+\ VIC bank = $c000
+$dd00 lda, %11111100 and,# $dd00 sta,
+
+\ Use Kernal variables to set up screen
+\ mode. The Kernal IRQ handler picks
+\ these up and sets up the VIC
+\ accordingly.
+
+\ hi-res mode
+%00100000 lda,# $d8 sta,
+\ VIC sees RAM instead of character ROM
+%00000100 lda,# $d9 sta,
+\ value at $0a2d gets put into $d018
+$80 lda,# $0a2d sta,
+;code
+
+code lores
+$dd00 lda, %00000011 ora,# $dd00 sta,
+$0 lda,# $d8 sta, $d9 sta,
+$78 lda,# $0a2d sta,
+;code

--- a/forth_src/c128/kernal.fs
+++ b/forth_src/c128/kernal.fs
@@ -1,0 +1,4 @@
+\ Definitions for kernal vars
+
+\ TBLX - cursor line number
+$eb constant k-tblx

--- a/forth_src/c128/sys.fs
+++ b/forth_src/c128/sys.fs
@@ -1,0 +1,25 @@
+include c128
+
+\ 'far' SYS that calls 128 kernal JSRFAR
+$06 value ar $07 value xr 
+$08 value yr $05 value sr
+code sysfar ( bank addr -- )
+\ JSRFAR uses $02-$05 ... better hope
+\ we aren't that deep in the stack ...
+
+\ set jump destination
+\ yes it is supposed to be MSB-first
+msb lda,x $03 sta, lsb lda,x $04 sta,
+inx, lsb lda,x $02 sta, inx, \ set bank
+\ save X and MMUCR
+\ JSRFAR does not save MMUCR and always 
+\ returns in bank 15
+txa, pha, $ff00 lda, pha,
+$ff6e jsr, \ JSRFAR
+pla, $ff00 sta, pla, tax,
+;code
+
+\ default sys for calling ROM routines
+: sys ( addr -- )
+\ bank $f = RAM0 + kernal + BASIC
+$f swap sysfar ;

--- a/forth_src/c128/vcore.fs
+++ b/forth_src/c128/vcore.fs
@@ -1,0 +1,7 @@
+code rom-kernal ;code
+code ram-kernal ;code
+: v-startup 
+$d7 c@ if
+abort" v only supports 40-column mode.
+press esc-x to switch modes."
+then ;

--- a/forth_src/c64/gfxcore.fs
+++ b/forth_src/c64/gfxcore.fs
@@ -1,0 +1,26 @@
+$e000 value bmpbase
+$cc00 value colbase
+
+code kernal-in
+$36 lda,# 1 sta, cli, ;code
+code kernal-out
+sei, $35 lda,# 1 sta, ;code
+code charrom-in
+$01 lda, $fb and,# $1 sta, ;code
+
+code hires
+$bb lda,# $d011 sta, \ enable bitmap mode
+$dd00 lda,
+%11111100 and,# \ vic bank 2
+$dd00 sta,
+$38 lda,# $d018 sta,
+;code
+
+code lores
+$9b lda,# $d011 sta,
+$dd00 lda,
+%11 ora,#
+$dd00 sta,
+$17 lda,#
+$d018 sta,
+;code

--- a/forth_src/c64/kernal.fs
+++ b/forth_src/c64/kernal.fs
@@ -1,0 +1,4 @@
+\ Definitions for kernal vars and routines
+
+\ TBLX - cursor line number
+$d6 constant k-tblx

--- a/forth_src/c64/sys.fs
+++ b/forth_src/c64/sys.fs
@@ -1,0 +1,9 @@
+( Calls Basic/Kernal routines.
+  Uses ar/xr/yr/sr for register I/O. )
+$30c value ar $30d value xr
+$30e value yr $30f value sr
+code sys ( addr -- )
+lsb lda,x $14 sta, msb lda,x $15 sta,
+txa, pha,
+$e130 jsr, \ perform [sys]
+pla, tax, inx, ;code

--- a/forth_src/c64/vcore.fs
+++ b/forth_src/c64/vcore.fs
@@ -1,0 +1,15 @@
+\ ram + io + kernal rom
+code rom-kernal
+$36 lda,# 1 sta, ;code
+\ ram + io + ram
+code ram-kernal
+$35 lda,# 1 sta, ;code
+
+\ modifies kernal to change kbd prefs
+: v-startup
+ram-kernal $eaea @ $8ca <> if
+rom-kernal
+$e000 dup $2000 move \ rom => ram
+$f $eaea c! \ repeat delay
+4 $eb1d c! \ repeat speed
+then ;

--- a/forth_src/debug.fs
+++ b/forth_src/debug.fs
@@ -97,7 +97,7 @@ last-dump ! base ! ;
 hide last-dump
 
 : more 
-$d6 c@ $18 = if $12 emit
+k-tblx c@ $18 = if $12 emit
 ." more" $92 emit key drop page then ;
 
 : (words) more name>string type space 1 ;

--- a/forth_src/gfx.fs
+++ b/forth_src/gfx.fs
@@ -1,32 +1,12 @@
 base @ hex
-e000 value bmpbase
-cc00 value colbase
 
-code kernal-in
-36 lda,# 1 sta, cli, ;code
-code kernal-out
-sei, 35 lda,# 1 sta, ;code
-
-code hires
-bb lda,# d011 sta, \ enable bitmap mode
-dd00 lda,
-%11111100 and,# \ vic bank 2
-dd00 sta,
-38 lda,# d018 sta,
-;code
-
-code lores
-9b lda,# d011 sta,
-dd00 lda,
-%11 ora,#
-dd00 sta,
-17 lda,#
-d018 sta,
-;code
+include gfxcore
 
 : clrcol ( fgbgcol -- )
+kernal-out
 colbase 3e8 rot fill
-bmpbase 1f40 0 fill ;
+bmpbase 1f40 0 fill 
+kernal-in ;
 
 : blkcol ( col row c -- )
 -rot 28 * + colbase + c! ;
@@ -89,7 +69,8 @@ w lda,(y) w3 sta,
 
 clc,
 lsb 1+ lda,x f8 and,# lsb adc,x lsb sta,x
-msb 1+ lda,x msb adc,x clc, e0 adc,# msb sta,x
+msb 1+ lda,x msb adc,x clc, 
+bmpbase 100/ adc,# msb sta,x
 w3 lda, lsb 1+ sta,x
 0 lda,# msb 1+ sta,x
 rts,
@@ -587,13 +568,12 @@ kernal-out
 \ addr=dst
 rot 140 * addr !
 rot 8 * bmpbase + addr +!
-\ disable interrupt,enable char rom
-1 c@ dup >r fb and 1 c!
+charrom-in
 begin ?dup while
 swap dup c@ pet>scr 8 * d800 +
 addr @ 8 move
 1+ swap 8 addr +! 1- repeat
-r> 1 c! drop kernal-in ;
+drop kernal-in ;
 
 : drawchar ( col row srcaddr -- )
 kernal-out

--- a/forth_src/m65/gfxcore.fs
+++ b/forth_src/m65/gfxcore.fs
@@ -1,0 +1,26 @@
+$e000 value bmpbase
+$cc00 value colbase
+
+code kernal-in
+$36 lda,# 1 sta, cli, ;code
+code kernal-out
+sei, $35 lda,# 1 sta, ;code
+code charrom-in
+$01 lda, $fb and,# $1 sta, ;code
+
+code hires
+$bb lda,# $d011 sta, \ enable bitmap mode
+$dd00 lda,
+%11111100 and,# \ vic bank 2
+$dd00 sta,
+$38 lda,# $d018 sta,
+;code
+
+code lores
+$9b lda,# $d011 sta,
+$dd00 lda,
+%11 ora,#
+$dd00 sta,
+$17 lda,#
+$d018 sta,
+;code

--- a/forth_src/m65/kernal.fs
+++ b/forth_src/m65/kernal.fs
@@ -1,0 +1,4 @@
+\ Definitions for kernal vars and routines
+
+\ TBLX - cursor line number
+$d6 constant k-tblx

--- a/forth_src/m65/sys.fs
+++ b/forth_src/m65/sys.fs
@@ -1,0 +1,9 @@
+( Calls Basic/Kernal routines.
+  Uses ar/xr/yr/sr for register I/O. )
+$30c value ar $30d value xr
+$30e value yr $30f value sr
+code sys ( addr -- )
+lsb lda,x $14 sta, msb lda,x $15 sta,
+txa, pha,
+$e130 jsr, \ perform [sys]
+pla, tax, inx, ;code

--- a/forth_src/m65/vcore.fs
+++ b/forth_src/m65/vcore.fs
@@ -1,0 +1,15 @@
+\ ram + io + kernal rom
+code rom-kernal
+$36 lda,# 1 sta, ;code
+\ ram + io + ram
+code ram-kernal
+$35 lda,# 1 sta, ;code
+
+\ modifies kernal to change kbd prefs
+: v-startup
+ram-kernal $eaea @ $8ca <> if
+rom-kernal
+$e000 dup $2000 move \ rom => ram
+$f $eaea c! \ repeat delay
+4 $eb1d c! \ repeat speed
+then ;

--- a/forth_src/platform.fs
+++ b/forth_src/platform.fs
@@ -1,0 +1,14 @@
+marker ---get-platform---
+
+\ use IRQ vector to identify which
+\ system we are running on
+: get-platform 
+$fffe @ case
+$ff48 of 64 endof
+$ff17 of 128 endof
+abort" cannot identify platform"
+endcase ;
+
+get-platform
+---get-platform---
+constant platform

--- a/forth_src/sys.fs
+++ b/forth_src/sys.fs
@@ -1,9 +1,0 @@
-( Calls Basic/Kernal routines.
-  Uses ar/xr/yr/sr for register I/O. )
-$30c value ar $30d value xr
-$30e value yr $30f value sr
-code sys ( addr -- )
-lsb lda,x $14 sta, msb lda,x $15 sta,
-txa, pha,
-$e130 jsr, \ perform [sys]
-pla, tax, inx, ;code

--- a/forth_src/turnkey.fs
+++ b/forth_src/turnkey.fs
@@ -23,7 +23,7 @@ start @ to oldstart
 top to oldtop 
 ['] newstart start ! 
 here $20 + top latest - + top!
-$801 top 1+ $d word count saveb
+basic-start top 1+ $d word count saveb
 restore-forth ;
 
 : save-prg ( strptr strlen -- )

--- a/forth_src/v.fs
+++ b/forth_src/v.fs
@@ -4,6 +4,8 @@ header v
 
 latest \ begin hiding words
 
+include vcore
+
 $d value lf
 
 $7001 value bufstart
@@ -40,7 +42,7 @@ msb ldy,x w 1+ sty,
 0 ldy,#
 here w lda,(y)
 0 cmp,# foundeol -branch beq,
-$e716 jsr, iny, \ putchar
+$ffd2 jsr, iny, \ putchar
 $d cmp,# foundeol -branch beq, jmp,
 
 \ nb: may return eof
@@ -73,13 +75,6 @@ curx @ linelen min +
 $400 + ( addr ) ;
 
 : sol 0 curx ! ;
-
-\ ram + io + kernal rom
-code rom-kernal
-$36 lda,# 1 sta, ;code
-\ ram + io + ram
-code ram-kernal
-$35 lda,# 1 sta, ;code
 
 : reset-buffer
 0 bufstart 1- c!
@@ -193,7 +188,7 @@ begin advance-cur editpos 1+ dup
 eof= swap c@ space= or or until ;
 
 : setcur ( x y -- )
-xr ! yr ! $e50c sys ;
+xr ! yr ! 0 sr ! $fff0 sys ;
 
 : refresh-line
 cury @ $28 * $400 + $28 bl fill
@@ -618,13 +613,7 @@ curlinestart @ bufstart eof @ within
 0= abort" cl" again ;
 
 define v
-\ modifies kernal to change kbd prefs
-ram-kernal $eaea @ $8ca <> if
-rom-kernal
-$e000 dup $2000 move \ rom => ram
-$f $eaea c! \ repeat delay
-4 $eb1d c! \ repeat speed
-then
+v-startup \ platform-specific startup
 
 0 to insert
 $80 $28a c! \ key repeat on

--- a/interpreter.asm
+++ b/interpreter.asm
@@ -38,7 +38,13 @@ quit_reset
 !if TARGET = 128 {
     lda #0
     sta SCREEN_MODE
-} else {
+} 
+
+!if TARGET = 65 {
+
+} 
+
+!if TARGET = 64 {
     lda #$9b
     sta VIC_CR1
     lda #$17

--- a/io.asm
+++ b/io.asm
@@ -36,7 +36,7 @@ PAGE
     +BACKLINK "type", 4
 TYPE ; ( caddr u -- )
     lda #0 ; quote mode off
-    sta $d4
+    sta QTSW
 -   lda LSB,x
     ora MSB,x
     bne +
@@ -51,7 +51,11 @@ TYPE ; ( caddr u -- )
     jmp -
 
     +BACKLINK "key?", 4
-    lda $c6 ; Number of characters in keyboard buffer
+!if TARGET = 128 {
+    lda MACRO_NDX ; Number of characters pending from function-key macro
+    bne .pushtrue
+}
+    lda NDX
     beq +
 .pushtrue
     lda #$ff
@@ -59,10 +63,14 @@ TYPE ; ( caddr u -- )
     jmp pushya
 
     +BACKLINK "key", 3
--   lda $c6
+!if TARGET = 128 {
+    lda MACRO_NDX ; Number of characters pending from function-key macro
+    bne +
+}
+-   lda NDX
     beq -
-    stx W
-    jsr $e5b4 ; Get character from keyboard buffer
++   stx W
+    jsr KEYIN ; Get character from keyboard buffer
     ldx W
     ldy #0
     jmp pushya
@@ -102,7 +110,7 @@ READ_EOF = * + 1
 .getLineFromConsole
     stx W
     ldx #0
--   jsr $e112 ; Input Character
+-   jsr CHRIN ; Input Character
     cmp #$d
     beq .gotReturn
     sta TIB,x

--- a/io.asm
+++ b/io.asm
@@ -66,11 +66,22 @@ TYPE ; ( caddr u -- )
 !if TARGET = 128 {
     lda MACRO_NDX ; Number of characters pending from function-key macro
     bne +
-}
 -   lda NDX
     beq -
+}
+
+!if TARGET = 64 {
+-   lda NDX
+    beq -   
+}
+
 +   stx W
-    jsr KEYIN ; Get character from keyboard buffer
+-   jsr KEYIN ; Get character from keyboard buffer
+
+!if TARGET = 65 {
+    beq -
+}
+
     ldx W
     ldy #0
     jmp pushya


### PR DESCRIPTION
Based on the c128 port, I was able to get this working on xemu, the Mega65 emulator.  On the first run (when its building the new forth system) it will crash into the monitor and the screen will go blank.  Resetting the emulated machine and loading/running again will finish the job and go into interpret mode.   Any issues are likely in the kernal.fs / sys.fs / vcore.fs because I just copied them from the c64 files.